### PR TITLE
Create minimal CLI app

### DIFF
--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -6,5 +6,7 @@
 !.gitignore
 !package.json
 !tsconfig.json
+!biome.json
 !src/
+!src/**
 !README.md

--- a/packages/cli/biome.json
+++ b/packages/cli/biome.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.7/schema.json",
+  "extends": "//"
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,9 +1,16 @@
 {
   "name": "@tinywhale/cli",
   "version": "0.0.0",
+  "type": "module",
   "description": "TinyWhale command-line interface",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "bin": {
     "tinywhale": "./dist/cli.js"
   },
@@ -11,9 +18,10 @@
     "dist"
   ],
   "scripts": {
-    "build": "echo 'Build script not yet configured'",
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "test": "echo 'Test script not yet configured'",
-    "lint": "echo 'Lint script not yet configured'",
+    "lint": "biome check src",
     "clean": "rm -rf dist",
     "dev": "echo 'Dev script not yet configured'"
   },
@@ -26,5 +34,10 @@
   "dependencies": {
     "@adonisjs/ace": "13.4.0",
     "@tinywhale/compiler": "workspace:*"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.3.7",
+    "@types/node": "22.15.29",
+    "typescript": "5.9.3"
   }
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+import { Kernel } from '@adonisjs/ace';
+
+const version = '0.0.0';
+
+async function main(): Promise<void> {
+  const kernel = Kernel.create();
+
+  kernel.info.set('binary', 'tinywhale');
+  kernel.info.set('version', version);
+
+  kernel.defineFlag('help', {
+    type: 'boolean',
+    alias: 'h',
+    description: 'Display help information',
+  });
+
+  kernel.defineFlag('version', {
+    type: 'boolean',
+    alias: 'v',
+    description: 'Display version number',
+  });
+
+  kernel.on('finding:command', async () => {
+    console.log(`TinyWhale v${version}`);
+    console.log('');
+    console.log('Usage: tinywhale [command] [options]');
+    console.log('');
+    console.log('Run "tinywhale --help" for available commands and options.');
+    return true;
+  });
+
+  await kernel.handle(process.argv.slice(2));
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * TinyWhale CLI - Library exports
+ *
+ * This module exports the public API for the TinyWhale CLI.
+ * Currently minimal as the compiler is not yet available.
+ */
+
+export const version = '0.0.0';

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ESNext"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Set up the TinyWhale CLI based on AdonisJS Ace v13:
- Entry point (src/cli.ts) with Kernel setup
- Prints version and help message when run without arguments
- Library export (src/index.ts) for programmatic use
- TypeScript configuration with ESM output
- Build scripts using tsc