### PR TITLE
feat(compiler): add streaming indentation preprocessor

### DIFF
--- a/packages/compiler/.gitignore
+++ b/packages/compiler/.gitignore
@@ -8,4 +8,6 @@
 !biome.json
 !src/
 !src/**
+!test/
+!test/**
 !README.md

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -7,6 +7,7 @@
   "description": "TinyWhale compiler library",
   "devDependencies": {
     "@biomejs/biome": "2.3.7",
+    "@types/node": "22.15.29",
     "typescript": "5.9.3"
   },
   "exports": {
@@ -26,11 +27,12 @@
   "main": "./dist/index.js",
   "name": "@tinywhale/compiler",
   "scripts": {
-    "build": "echo 'Build script not yet configured'",
+    "build": "tsc",
     "clean": "rm -rf dist",
-    "lint": "echo 'Lint script not yet configured'",
-    "test": "echo 'Test script not yet configured'"
+    "lint": "biome check src test",
+    "test": "node --test test/**/*.test.ts"
   },
+  "type": "module",
   "types": "./dist/index.d.ts",
   "version": "0.0.0"
 }

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,3 +1,9 @@
 import * as ohm from 'ohm-js';
 
 export { ohm };
+export {
+  preprocess,
+  IndentationError,
+  type IndentMode,
+  type PreprocessOptions,
+} from './preprocessor/index.js';

--- a/packages/compiler/src/preprocessor/index.ts
+++ b/packages/compiler/src/preprocessor/index.ts
@@ -1,0 +1,364 @@
+import { Readable } from 'node:stream';
+
+/**
+ * Token types for indentation.
+ */
+type IndentType = 'tab' | 'space';
+
+/**
+ * Indentation mode for the preprocessor.
+ * - 'detect': First indentation character encountered sets the file-wide type (default)
+ * - 'directive': Respects "use spaces" directive, otherwise defaults to tabs
+ */
+export type IndentMode = 'detect' | 'directive';
+
+/**
+ * Options for the preprocessor.
+ */
+export interface PreprocessOptions {
+  mode?: IndentMode;
+}
+
+/**
+ * Error thrown when mixed indentation is detected.
+ */
+export class IndentationError extends Error {
+  readonly line: number;
+  readonly column: number;
+  readonly expected: IndentType;
+  readonly found: IndentType;
+
+  constructor(
+    message: string,
+    line: number,
+    column: number,
+    expected: IndentType,
+    found: IndentType
+  ) {
+    super(message);
+    this.name = 'IndentationError';
+    this.line = line;
+    this.column = column;
+    this.expected = expected;
+    this.found = found;
+  }
+}
+
+/**
+ * Represents a position in the source text.
+ * Line and column are 1-indexed.
+ */
+interface Position {
+  line: number;
+  column: number;
+}
+
+/**
+ * Result of analyzing a line's indentation.
+ */
+interface LineIndentInfo {
+  type: IndentType | null;
+  count: number;
+}
+
+/**
+ * UTF-8 Byte Order Mark (BOM) character.
+ * Unnecessary for UTF-8 but sometimes added by editors. We strip it.
+ */
+const UTF8_BOM = '\uFEFF';
+
+/**
+ * Creates an indentation token string.
+ * Format: indent_<type>:<startLine>,<startCol>;<endLine>,<endCol>
+ */
+function createIndentToken(
+  type: IndentType,
+  start: Position,
+  end: Position
+): string {
+  return `indent_${type}:${start.line},${start.column};${end.line},${end.column}`;
+}
+
+/**
+ * Analyzes a line's leading whitespace.
+ * Throws IndentationError if mixed indentation is found on the same line.
+ */
+function analyzeLineIndent(line: string, lineNumber: number): LineIndentInfo {
+  if (line.length === 0) {
+    return { type: null, count: 0 };
+  }
+
+  let indentEnd = 0;
+  let indentType: IndentType | null = null;
+
+  while (indentEnd < line.length) {
+    const char = line[indentEnd];
+    if (char === '\t') {
+      if (indentType === null) {
+        indentType = 'tab';
+      } else if (indentType !== 'tab') {
+        throw new IndentationError(
+          `${lineNumber}:${indentEnd + 1} Mixed indentation: found tab after spaces. Use spaces only for indentation on this line.`,
+          lineNumber,
+          indentEnd + 1,
+          indentType,
+          'tab'
+        );
+      }
+      indentEnd++;
+    } else if (char === ' ') {
+      if (indentType === null) {
+        indentType = 'space';
+      } else if (indentType !== 'space') {
+        throw new IndentationError(
+          `${lineNumber}:${indentEnd + 1} Mixed indentation: found space after tabs. Use tabs only for indentation on this line.`,
+          lineNumber,
+          indentEnd + 1,
+          indentType,
+          'space'
+        );
+      }
+      indentEnd++;
+    } else {
+      break;
+    }
+  }
+
+  return { type: indentType, count: indentEnd };
+}
+
+/**
+ * Processes a single line and returns the tokenized version.
+ */
+function processLine(
+  line: string,
+  lineNumber: number,
+  indentInfo: LineIndentInfo
+): string {
+  if (line.length === 0 || indentInfo.type === null || indentInfo.count === 0) {
+    return line;
+  }
+
+  const start: Position = { line: lineNumber, column: 1 };
+  const end: Position = { line: lineNumber, column: indentInfo.count };
+  const token = createIndentToken(indentInfo.type, start, end);
+  const rest = line.slice(indentInfo.count);
+
+  return `${token} ${rest}`;
+}
+
+/**
+ * Parses a "use spaces" directive from a line.
+ * Returns 'space' if directive found, null otherwise.
+ */
+function parseDirective(line: string): IndentType | null {
+  const trimmed = line.trim();
+  if (trimmed === '"use spaces"' || trimmed === "'use spaces'") {
+    return 'space';
+  }
+  return null;
+}
+
+/**
+ * State tracked during streaming processing.
+ */
+interface ProcessingState {
+  mode: IndentMode;
+  lineNumber: number;
+  expectedIndentType: IndentType | null;
+  indentEstablishedAt: { line: number; source: 'directive' | 'detected' } | null;
+  directiveLine: number | null;
+  // For directive mode: buffer lines until we find directive or finish
+  // We need to do a two-pass in directive mode since directive can appear after indented lines
+  bufferedLines: { line: string; lineNumber: number; indentInfo: LineIndentInfo }[];
+  directiveFound: boolean;
+  isFirstChunk: boolean;
+}
+
+/**
+ * Validates indentation consistency and throws if mismatched.
+ */
+function validateIndent(
+  indentInfo: LineIndentInfo,
+  lineNumber: number,
+  state: ProcessingState
+): void {
+  if (indentInfo.type === null) {
+    return;
+  }
+
+  if (state.expectedIndentType === null) {
+    // First indent sets the type (detect mode)
+    state.expectedIndentType = indentInfo.type;
+    state.indentEstablishedAt = { line: lineNumber, source: 'detected' };
+  } else if (indentInfo.type !== state.expectedIndentType) {
+    const plural = state.expectedIndentType === 'tab' ? 'tabs' : 'spaces';
+    const foundPlural = indentInfo.type === 'tab' ? 'tabs' : 'spaces';
+    let context: string;
+    if (state.indentEstablishedAt?.source === 'directive') {
+      context = state.indentEstablishedAt.line === 0
+        ? `File uses ${plural} by default (no "use spaces" directive at the top of file found).`
+        : `File uses ${plural} ("use spaces" directive on line ${state.indentEstablishedAt.line}).`;
+    } else {
+      context = `File uses ${plural} (first indented line: ${state.indentEstablishedAt?.line}).`;
+    }
+    throw new IndentationError(
+      `${lineNumber}:1 Unexpected ${foundPlural}. ${context} Convert this line to use ${plural}.`,
+      lineNumber,
+      1,
+      state.expectedIndentType,
+      indentInfo.type
+    );
+  }
+}
+
+/**
+ * Preprocesses source code by tokenizing indentation.
+ *
+ * This is the first phase of compilation that operates on raw text streams.
+ * It replaces leading whitespace (tabs or spaces) with explicit tokens that
+ * include position information.
+ *
+ * The preprocessor operates in two modes:
+ * - 'detect' (default): First indentation character sets file-wide type
+ * - 'directive': Respects "use spaces" directive, defaults to tabs
+ *
+ * Mixed indentation (tabs and spaces in the same file) causes an error.
+ *
+ * Token format: indent_<type>:<startLine>,<startCol>;<endLine>,<endCol>
+ * Examples:
+ *   - indent_tab:1,1;1,1 (single tab on line 1)
+ *   - indent_space:2,1;2,4 (4 spaces on line 2)
+ *
+ * @param stream - A readable stream of UTF-8 text
+ * @param options - Preprocessor options
+ * @returns The preprocessed text with indentation tokens
+ * @throws IndentationError if mixed indentation is detected
+ */
+export async function preprocess(
+  stream: Readable,
+  options: PreprocessOptions = {}
+): Promise<string> {
+  const { mode = 'detect' } = options;
+
+  const state: ProcessingState = {
+    mode,
+    lineNumber: 0,
+    expectedIndentType: mode === 'directive' ? 'tab' : null,
+    indentEstablishedAt: mode === 'directive' ? { line: 0, source: 'directive' } : null,
+    directiveLine: null,
+    bufferedLines: [],
+    directiveFound: false,
+    isFirstChunk: true,
+  };
+
+  const processedLines: string[] = [];
+  let pendingChunk = '';
+
+  for await (const chunk of stream) {
+    let str = typeof chunk === 'string' ? chunk : chunk.toString('utf-8');
+
+    // Strip UTF-8 BOM if present at the very start
+    if (state.isFirstChunk) {
+      if (str.startsWith(UTF8_BOM)) {
+        str = str.slice(1);
+      }
+      state.isFirstChunk = false;
+    }
+
+    // Combine with any pending partial line from previous chunk
+    pendingChunk += str;
+
+    // Process complete lines
+    const lines = pendingChunk.split('\n');
+    // Keep the last element as pending (may be incomplete)
+    pendingChunk = lines.pop() ?? '';
+
+    for (const line of lines) {
+      state.lineNumber++;
+      const lineNumber = state.lineNumber;
+
+      // Check for directive in directive mode
+      if (mode === 'directive' && !state.directiveFound) {
+        const directive = parseDirective(line);
+        if (directive !== null) {
+          state.directiveFound = true;
+          state.directiveLine = lineNumber;
+          state.expectedIndentType = directive;
+          state.indentEstablishedAt = { line: lineNumber, source: 'directive' };
+
+          // Validate all buffered lines against the directive (but don't output them)
+          // Lines before the directive are discarded along with the directive
+          for (const buffered of state.bufferedLines) {
+            validateIndent(buffered.indentInfo, buffered.lineNumber, state);
+          }
+          state.bufferedLines = [];
+          // Don't output the directive line itself
+          continue;
+        }
+      }
+
+      const indentInfo = analyzeLineIndent(line, lineNumber);
+
+      if (mode === 'directive' && !state.directiveFound) {
+        // Buffer the line - we might find a directive later
+        state.bufferedLines.push({ line, lineNumber, indentInfo });
+      } else {
+        validateIndent(indentInfo, lineNumber, state);
+        processedLines.push(processLine(line, lineNumber, indentInfo));
+      }
+    }
+  }
+
+  // Process any remaining content (last line without trailing newline)
+  if (pendingChunk.length > 0) {
+    state.lineNumber++;
+    const lineNumber = state.lineNumber;
+
+    // Check for directive
+    if (mode === 'directive' && !state.directiveFound) {
+      const directive = parseDirective(pendingChunk);
+      if (directive !== null) {
+        state.directiveFound = true;
+        state.directiveLine = lineNumber;
+        state.expectedIndentType = directive;
+        state.indentEstablishedAt = { line: lineNumber, source: 'directive' };
+
+        // Validate buffered lines (but don't output - they're discarded with directive)
+        for (const buffered of state.bufferedLines) {
+          validateIndent(buffered.indentInfo, buffered.lineNumber, state);
+        }
+        state.bufferedLines = [];
+        // Don't output the directive line
+      } else {
+        const indentInfo = analyzeLineIndent(pendingChunk, lineNumber);
+        state.bufferedLines.push({ line: pendingChunk, lineNumber, indentInfo });
+      }
+    } else {
+      const indentInfo = analyzeLineIndent(pendingChunk, lineNumber);
+      validateIndent(indentInfo, lineNumber, state);
+      processedLines.push(processLine(pendingChunk, lineNumber, indentInfo));
+    }
+  }
+
+  // If in directive mode and no directive was found, validate and output buffered lines
+  if (mode === 'directive' && !state.directiveFound && state.bufferedLines.length > 0) {
+    for (const buffered of state.bufferedLines) {
+      validateIndent(buffered.indentInfo, buffered.lineNumber, state);
+      processedLines.push(processLine(buffered.line, buffered.lineNumber, buffered.indentInfo));
+    }
+  }
+
+  // Determine if original had trailing newline
+  // If the last chunk was empty string after split, there was a trailing newline
+  const result = processedLines.join('\n');
+
+  // Check if stream ended with newline by seeing if pendingChunk was empty
+  // Actually we need to track this differently...
+  // If pendingChunk is empty after processing, that means the stream ended with \n
+  if (pendingChunk.length === 0 && state.lineNumber > 0) {
+    return result + '\n';
+  }
+
+  return result;
+}

--- a/packages/compiler/test/fixtures/directive-after-indent.tw
+++ b/packages/compiler/test/fixtures/directive-after-indent.tw
@@ -1,0 +1,3 @@
+	indented
+"use spaces"
+	indented again

--- a/packages/compiler/test/fixtures/mixed-indent.tw
+++ b/packages/compiler/test/fixtures/mixed-indent.tw
@@ -1,0 +1,6 @@
+hello
+	tab-indented
+  space-indented
+	 tab-then-space
+ 	space-then-tab
+done

--- a/packages/compiler/test/fixtures/no-indent.tw
+++ b/packages/compiler/test/fixtures/no-indent.tw
@@ -1,0 +1,3 @@
+hello
+world
+done

--- a/packages/compiler/test/fixtures/spaces-only.tw
+++ b/packages/compiler/test/fixtures/spaces-only.tw
@@ -1,0 +1,5 @@
+hello
+  world
+    nested
+  back
+done

--- a/packages/compiler/test/fixtures/tabs-only.tw
+++ b/packages/compiler/test/fixtures/tabs-only.tw
@@ -1,0 +1,5 @@
+hello
+	world
+		nested
+	back
+done

--- a/packages/compiler/test/fixtures/uneven-spaces.tw
+++ b/packages/compiler/test/fixtures/uneven-spaces.tw
@@ -1,0 +1,7 @@
+hello
+ one
+   three
+     five
+  two
+       seven
+done

--- a/packages/compiler/test/fixtures/with-bom.tw
+++ b/packages/compiler/test/fixtures/with-bom.tw
@@ -1,0 +1,3 @@
+﻿"use spaces"
+hello
+  world

--- a/packages/compiler/test/preprocessor.test.ts
+++ b/packages/compiler/test/preprocessor.test.ts
@@ -1,0 +1,346 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { createReadStream } from 'node:fs';
+import { Readable } from 'node:stream';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { preprocess, IndentationError } from '../src/preprocessor/index.ts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function fixturesPath(name: string): string {
+  return join(__dirname, 'fixtures', name);
+}
+
+function streamFromString(text: string): Readable {
+  return Readable.from(text);
+}
+
+describe('preprocessor', () => {
+  describe('indentation tokenization', () => {
+    it('should handle empty input', async () => {
+      const stream = streamFromString('');
+      const result = await preprocess(stream);
+      assert.strictEqual(result, '');
+    });
+
+    it('should pass through text without indentation unchanged', async () => {
+      const stream = streamFromString('hello\nworld\ndone\n');
+      const result = await preprocess(stream);
+      assert.strictEqual(result, 'hello\nworld\ndone\n');
+    });
+
+    it('should tokenize leading tabs', async () => {
+      const stream = streamFromString('\thello');
+      const result = await preprocess(stream);
+      assert.strictEqual(result, 'indent_tab:1,1;1,1 hello');
+    });
+
+    it('should tokenize multiple leading tabs', async () => {
+      const stream = streamFromString('\t\thello');
+      const result = await preprocess(stream);
+      assert.strictEqual(result, 'indent_tab:1,1;1,2 hello');
+    });
+
+    it('should tokenize leading spaces', async () => {
+      const stream = streamFromString('  hello');
+      const result = await preprocess(stream);
+      assert.strictEqual(result, 'indent_space:1,1;1,2 hello');
+    });
+
+    it('should tokenize multiple lines with tabs', async () => {
+      const stream = streamFromString('hello\n\tworld\n\t\tnested\n');
+      const result = await preprocess(stream);
+      assert.strictEqual(
+        result,
+        'hello\nindent_tab:2,1;2,1 world\nindent_tab:3,1;3,2 nested\n'
+      );
+    });
+
+    it('should tokenize multiple lines with spaces', async () => {
+      const stream = streamFromString('hello\n  world\n    nested\n');
+      const result = await preprocess(stream);
+      assert.strictEqual(
+        result,
+        'hello\nindent_space:2,1;2,2 world\nindent_space:3,1;3,4 nested\n'
+      );
+    });
+
+    it('should handle lines that return to no indentation', async () => {
+      const stream = streamFromString('hello\n\tworld\nback\n');
+      const result = await preprocess(stream);
+      assert.strictEqual(result, 'hello\nindent_tab:2,1;2,1 world\nback\n');
+    });
+
+    it('should preserve empty lines', async () => {
+      const stream = streamFromString('hello\n\nworld\n');
+      const result = await preprocess(stream);
+      assert.strictEqual(result, 'hello\n\nworld\n');
+    });
+
+    it('should handle indentation on first line', async () => {
+      const stream = streamFromString('\tfirst\nsecond\n');
+      const result = await preprocess(stream);
+      assert.strictEqual(result, 'indent_tab:1,1;1,1 first\nsecond\n');
+    });
+  });
+
+  describe('mixed indentation errors', () => {
+    it('should throw on tab then space on same line', async () => {
+      const stream = streamFromString('\t hello');
+      await assert.rejects(
+        () => preprocess(stream),
+        (err: IndentationError) => {
+          assert.strictEqual(err.name, 'IndentationError');
+          assert.strictEqual(err.line, 1);
+          assert.strictEqual(err.column, 2);
+          assert.strictEqual(err.expected, 'tab');
+          assert.strictEqual(err.found, 'space');
+          return true;
+        }
+      );
+    });
+
+    it('should throw on space then tab on same line', async () => {
+      const stream = streamFromString(' \thello');
+      await assert.rejects(
+        () => preprocess(stream),
+        (err: IndentationError) => {
+          assert.strictEqual(err.name, 'IndentationError');
+          assert.strictEqual(err.line, 1);
+          assert.strictEqual(err.column, 2);
+          assert.strictEqual(err.expected, 'space');
+          assert.strictEqual(err.found, 'tab');
+          return true;
+        }
+      );
+    });
+
+    it('should throw on mixed indentation across lines (tabs then spaces)', async () => {
+      const stream = streamFromString('hello\n\tworld\n  nested\n');
+      await assert.rejects(
+        () => preprocess(stream),
+        (err: IndentationError) => {
+          assert.strictEqual(err.name, 'IndentationError');
+          assert.strictEqual(err.line, 3);
+          assert.strictEqual(err.expected, 'tab');
+          assert.strictEqual(err.found, 'space');
+          return true;
+        }
+      );
+    });
+
+    it('should throw on mixed indentation across lines (spaces then tabs)', async () => {
+      const stream = streamFromString('hello\n  world\n\tnested\n');
+      await assert.rejects(
+        () => preprocess(stream),
+        (err: IndentationError) => {
+          assert.strictEqual(err.name, 'IndentationError');
+          assert.strictEqual(err.line, 3);
+          assert.strictEqual(err.expected, 'space');
+          assert.strictEqual(err.found, 'tab');
+          return true;
+        }
+      );
+    });
+  });
+
+  describe('directive mode', () => {
+    it('should default to tabs when no directive present', async () => {
+      const stream = streamFromString('hello\n  world\n');
+      await assert.rejects(
+        () => preprocess(stream, { mode: 'directive' }),
+        (err: IndentationError) => {
+          assert.strictEqual(err.expected, 'tab');
+          assert.strictEqual(err.found, 'space');
+          return true;
+        }
+      );
+    });
+
+    it('should allow tabs by default in directive mode', async () => {
+      const stream = streamFromString('hello\n\tworld\n');
+      const result = await preprocess(stream, { mode: 'directive' });
+      assert.strictEqual(result, 'hello\nindent_tab:2,1;2,1 world\n');
+    });
+
+    it('should respect "use spaces" directive with double quotes', async () => {
+      const stream = streamFromString('"use spaces"\nhello\n  world\n');
+      const result = await preprocess(stream, { mode: 'directive' });
+      assert.strictEqual(result, 'hello\nindent_space:3,1;3,2 world\n');
+    });
+
+    it('should respect "use spaces" directive with single quotes', async () => {
+      const stream = streamFromString("'use spaces'\nhello\n  world\n");
+      const result = await preprocess(stream, { mode: 'directive' });
+      assert.strictEqual(result, 'hello\nindent_space:3,1;3,2 world\n');
+    });
+
+    it('should reject tabs when "use spaces" directive is present', async () => {
+      const stream = streamFromString('"use spaces"\nhello\n\tworld\n');
+      await assert.rejects(
+        () => preprocess(stream, { mode: 'directive' }),
+        (err: IndentationError) => {
+          assert.strictEqual(err.expected, 'space');
+          assert.strictEqual(err.found, 'tab');
+          return true;
+        }
+      );
+    });
+
+    it('should strip directive line from output', async () => {
+      const stream = streamFromString('"use spaces"\nhello\n');
+      const result = await preprocess(stream, { mode: 'directive' });
+      assert.strictEqual(result, 'hello\n');
+    });
+
+    it('should find directive after empty lines', async () => {
+      const stream = streamFromString('\n\n\n\n\n"use spaces"\nhello\n  world\n');
+      const result = await preprocess(stream, { mode: 'directive' });
+      // Directive on line 6, content starts at line 7
+      assert.strictEqual(result, 'hello\nindent_space:8,1;8,2 world\n');
+    });
+
+    it('should report correct line number for directive after empty lines', async () => {
+      const stream = streamFromString('\n\n\n\n\n"use spaces"\nhello\n\tworld\n');
+      await assert.rejects(
+        () => preprocess(stream, { mode: 'directive' }),
+        (err: IndentationError) => {
+          assert.strictEqual(err.expected, 'space');
+          assert.strictEqual(err.found, 'tab');
+          assert.strictEqual(err.line, 8);
+          // Error message should mention line 6 where directive is
+          assert.match(err.message, /line 6/);
+          return true;
+        }
+      );
+    });
+
+    it('should honor directive even when indentation appears before it', async () => {
+      // File has tab indent on line 1, directive on line 2
+      // The directive should be honored and tabs should cause an error
+      const stream = streamFromString('\tindented\n"use spaces"\n\tindented again\n');
+      await assert.rejects(
+        () => preprocess(stream, { mode: 'directive' }),
+        (err: IndentationError) => {
+          assert.strictEqual(err.expected, 'space');
+          assert.strictEqual(err.found, 'tab');
+          // Should error on line 1 (the first tab indent)
+          assert.strictEqual(err.line, 1);
+          // Error message should mention line 2 where directive is
+          assert.match(err.message, /line 2/);
+          return true;
+        }
+      );
+    });
+
+    it('should process directive-after-indent.tw fixture', async () => {
+      const stream = createReadStream(fixturesPath('directive-after-indent.tw'), 'utf-8');
+      await assert.rejects(
+        () => preprocess(stream, { mode: 'directive' }),
+        (err: IndentationError) => {
+          assert.strictEqual(err.expected, 'space');
+          assert.strictEqual(err.found, 'tab');
+          assert.strictEqual(err.line, 1);
+          return true;
+        }
+      );
+    });
+  });
+
+  describe('detect mode (default)', () => {
+    it('should detect tabs from first indented line', async () => {
+      const stream = streamFromString('hello\n\tworld\n\tnested\n');
+      const result = await preprocess(stream);
+      assert.strictEqual(
+        result,
+        'hello\nindent_tab:2,1;2,1 world\nindent_tab:3,1;3,1 nested\n'
+      );
+    });
+
+    it('should detect spaces from first indented line', async () => {
+      const stream = streamFromString('hello\n  world\n  nested\n');
+      const result = await preprocess(stream);
+      assert.strictEqual(
+        result,
+        'hello\nindent_space:2,1;2,2 world\nindent_space:3,1;3,2 nested\n'
+      );
+    });
+
+    it('should allow files with no indentation', async () => {
+      const stream = streamFromString('hello\nworld\ndone\n');
+      const result = await preprocess(stream);
+      assert.strictEqual(result, 'hello\nworld\ndone\n');
+    });
+  });
+
+  describe('fixture file streaming', () => {
+    it('should process tabs-only.tw fixture', async () => {
+      const stream = createReadStream(fixturesPath('tabs-only.tw'), 'utf-8');
+      const result = await preprocess(stream);
+      assert.strictEqual(
+        result,
+        'hello\nindent_tab:2,1;2,1 world\nindent_tab:3,1;3,2 nested\nindent_tab:4,1;4,1 back\ndone\n'
+      );
+    });
+
+    it('should process spaces-only.tw fixture', async () => {
+      const stream = createReadStream(fixturesPath('spaces-only.tw'), 'utf-8');
+      const result = await preprocess(stream);
+      assert.strictEqual(
+        result,
+        'hello\nindent_space:2,1;2,2 world\nindent_space:3,1;3,4 nested\nindent_space:4,1;4,2 back\ndone\n'
+      );
+    });
+
+    it('should process no-indent.tw fixture', async () => {
+      const stream = createReadStream(fixturesPath('no-indent.tw'), 'utf-8');
+      const result = await preprocess(stream);
+      assert.strictEqual(result, 'hello\nworld\ndone\n');
+    });
+
+    it('should process empty.tw fixture', async () => {
+      const stream = createReadStream(fixturesPath('empty.tw'), 'utf-8');
+      const result = await preprocess(stream);
+      assert.strictEqual(result, '');
+    });
+
+    it('should reject mixed-indent.tw fixture (mixed across lines)', async () => {
+      const stream = createReadStream(fixturesPath('mixed-indent.tw'), 'utf-8');
+      await assert.rejects(
+        () => preprocess(stream),
+        (err: IndentationError) => {
+          assert.strictEqual(err.name, 'IndentationError');
+          // Line 3 has spaces after line 2 has tabs
+          assert.strictEqual(err.line, 3);
+          assert.strictEqual(err.expected, 'tab');
+          assert.strictEqual(err.found, 'space');
+          return true;
+        }
+      );
+    });
+
+    it('should process uneven-spaces.tw fixture', async () => {
+      const stream = createReadStream(fixturesPath('uneven-spaces.tw'), 'utf-8');
+      const result = await preprocess(stream);
+      assert.strictEqual(
+        result,
+        'hello\n' +
+          'indent_space:2,1;2,1 one\n' +
+          'indent_space:3,1;3,3 three\n' +
+          'indent_space:4,1;4,5 five\n' +
+          'indent_space:5,1;5,2 two\n' +
+          'indent_space:6,1;6,7 seven\n' +
+          'done\n'
+      );
+    });
+
+    it('should handle UTF-8 BOM and recognize directive (with-bom.tw)', async () => {
+      const stream = createReadStream(fixturesPath('with-bom.tw'), 'utf-8');
+      const result = await preprocess(stream, { mode: 'directive' });
+      // BOM should be stripped, directive recognized, spaces allowed
+      assert.strictEqual(result, 'hello\nindent_space:3,1;3,2 world\n');
+    });
+  });
+});

--- a/packages/compiler/tsconfig.json
+++ b/packages/compiler/tsconfig.json
@@ -1,8 +1,11 @@
 {
   "compilerOptions": {
-    "noEmit": true
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true
   },
-  "exclude": ["node_modules", "dist"],
+  "exclude": ["node_modules", "dist", "test"],
   "extends": "../../tsconfig.json",
   "include": ["src/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.3.7
         version: 2.3.7
+      '@types/node':
+        specifier: 22.15.29
+        version: 22.15.29
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -151,6 +154,9 @@ packages:
 
   '@types/bytes@3.1.5':
     resolution: {integrity: sha512-VgZkrJckypj85YxEsEavcMmmSOIzkUHqWmM4CCyia5dc54YwsXzJ5uT4fYxBQNEXx+oF1krlhgCbvfubXqZYsQ==}
+
+  '@types/node@22.15.29':
+    resolution: {integrity: sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==}
 
   '@types/node@24.10.1':
     resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
@@ -357,6 +363,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
@@ -486,6 +495,10 @@ snapshots:
       secure-json-parse: 4.1.0
 
   '@types/bytes@3.1.5': {}
+
+  '@types/node@22.15.29':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/node@24.10.1':
     dependencies:
@@ -649,6 +662,8 @@ snapshots:
   truncatise@0.0.8: {}
 
   typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
 


### PR DESCRIPTION
Implements a pre-parser phase that tokenizes leading whitespace in source files. The preprocessor operates on streams without loading entire files into memory.

Features:
- Two modes: 'detect' (auto-detect from first indent) and 'directive' (respects "use spaces" directive, defaults to tabs)
- Mixed indentation detection (same line and across lines)
- UTF-8 BOM stripping
- Actionable error messages with line numbers and context
- Token format: indent_<type>:<line>,<col>;<line>,<col>