### PR TITLE
refactor(compiler): simplify grammar

### DIFF
--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,28 +1,28 @@
 import * as ohm from 'ohm-js';
 
 export { ohm };
+
 export {
-  preprocess,
+  createSemantics,
+  grammars,
+  type IndentInfo,
+  type IndentToken,
+  match,
+  type ParsedLine,
+  type ParseResult,
+  type Position,
+  parse,
+  type Segment,
+  type SegmentType,
+  // Backwards compatibility
+  type SourcePosition,
+  semantics,
+  TinyWhaleGrammar,
+  trace,
+} from './grammar/index.js';
+export {
   IndentationError,
   type IndentMode,
   type PreprocessOptions,
+  preprocess,
 } from './preprocessor/index.js';
-
-export {
-  TinyWhaleGrammar,
-  grammars,
-  parse,
-  match,
-  trace,
-  createSemantics,
-  semantics,
-  type Position,
-  type IndentToken,
-  type Segment,
-  type SegmentType,
-  type ParsedLine,
-  type ParseResult,
-  // Backwards compatibility
-  type SourcePosition,
-  type IndentInfo,
-} from './grammar/index.js';

--- a/packages/compiler/test/grammar.test.ts
+++ b/packages/compiler/test/grammar.test.ts
@@ -1,14 +1,12 @@
-import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { Readable } from 'node:stream';
+import { describe, it } from 'node:test';
 import {
-  TinyWhaleGrammar,
-  grammars,
-  parse,
-  match,
   createSemantics,
   type IndentToken,
-  type Segment,
+  match,
+  parse,
+  TinyWhaleGrammar,
 } from '../src/grammar/index.ts';
 import { preprocess } from '../src/preprocessor/index.ts';
 
@@ -16,25 +14,11 @@ function streamFromString(text: string): Readable {
   return Readable.from(text);
 }
 
-/** Helper to get text content from segments */
-function getContent(segments: Segment[]): string {
-  return segments.map(s => s.type === 'comment' ? `#${s.content}#` : s.content).join('');
-}
-
-/** Helper to get raw text (ignoring comments) */
-function getTextOnly(segments: Segment[]): string {
-  return segments.filter(s => s.type === 'text').map(s => s.content).join('');
-}
-
 describe('grammar', () => {
   describe('grammar loading', () => {
     it('should load TinyWhale grammar', () => {
       assert.ok(TinyWhaleGrammar);
       assert.strictEqual(typeof TinyWhaleGrammar.match, 'function');
-    });
-
-    it('should export grammars object', () => {
-      assert.ok(grammars['TinyWhale']);
     });
   });
 
@@ -44,49 +28,50 @@ describe('grammar', () => {
       assert.ok(result.succeeded());
     });
 
-    it('should match content without indentation', () => {
-      const result = match('hello\nworld\n');
-      assert.ok(result.succeeded());
-    });
-
     it('should match single INDENT token', () => {
-      const result = match('⟨1,1⟩⇥hello\n');
+      const result = match('⟨1,1⟩⇥\n');
       assert.ok(result.succeeded());
     });
 
     it('should match single DEDENT token', () => {
-      const result = match('⟨2,0⟩⇤hello\n');
+      const result = match('⟨2,0⟩⇤\n');
       assert.ok(result.succeeded());
     });
 
     it('should match INDENT followed by DEDENT', () => {
-      const input = 'hello\n⟨2,1⟩⇥world\n⟨3,0⟩⇤back\n';
+      const input = '⟨1,1⟩⇥\n⟨2,0⟩⇤\n';
       const result = match(input);
       assert.ok(result.succeeded());
     });
 
     it('should match blank lines', () => {
-      const result = match('hello\n\nworld\n');
+      const result = match('\n\n\n');
       assert.ok(result.succeeded());
     });
 
     it('should match EOF dedents', () => {
-      const result = match('hello\n⟨2,1⟩⇥world\n⟨2,0⟩⇤');
+      const result = match('⟨1,1⟩⇥\n⟨2,0⟩⇤');
       assert.ok(result.succeeded());
     });
 
-    it('should match line comments', () => {
+    it('should skip line comments (treated as whitespace)', () => {
       const result = match('# this is a comment\n');
       assert.ok(result.succeeded());
     });
 
-    it('should match inline comments', () => {
-      const result = match('text # comment # more text\n');
+    it('should skip inline comments (treated as whitespace)', () => {
+      // Multiple toggle comments: # ... # # ... #
+      const result = match('⟨1,1⟩⇥ # comment # # more comment #\n');
       assert.ok(result.succeeded());
     });
 
-    it('should match empty comment (##)', () => {
+    it('should skip empty comment (##)', () => {
       const result = match('##\n');
+      assert.ok(result.succeeded());
+    });
+
+    it('should match indent token with surrounding comments', () => {
+      const result = match('# before # ⟨1,1⟩⇥ # after\n');
       assert.ok(result.succeeded());
     });
   });
@@ -98,42 +83,38 @@ describe('grammar', () => {
       assert.strictEqual(result.lines.length, 0);
     });
 
-    it('should parse content without indentation', () => {
-      const result = parse('hello\nworld\n');
+    it('should parse blank lines only (skipped as whitespace)', () => {
+      const result = parse('\n\n\n');
       assert.strictEqual(result.succeeded, true);
-      assert.strictEqual(result.lines.length, 2);
-      assert.strictEqual(result.lines[0].segments[0].content, 'hello');
-      assert.strictEqual(result.lines[0].indentTokens.length, 0);
+      assert.strictEqual(result.lines.length, 0); // no indent tokens
     });
 
     it('should parse single INDENT token', () => {
-      const result = parse('⟨1,1⟩⇥hello\n');
+      const result = parse('⟨1,1⟩⇥\n');
       assert.strictEqual(result.succeeded, true);
       assert.strictEqual(result.lines.length, 1);
 
       const line = result.lines[0];
-      assert.strictEqual(line.segments[0].content, 'hello');
       assert.strictEqual(line.indentTokens.length, 1);
       assert.strictEqual(line.indentTokens[0].type, 'indent');
       assert.deepStrictEqual(line.indentTokens[0].position, {
-        line: 1,
         level: 1,
+        line: 1,
       });
     });
 
     it('should parse DEDENT token', () => {
-      const result = parse('⟨2,0⟩⇤hello\n');
+      const result = parse('⟨2,0⟩⇤\n');
       assert.strictEqual(result.succeeded, true);
       assert.strictEqual(result.lines.length, 1);
 
       const line = result.lines[0];
-      assert.strictEqual(line.segments[0].content, 'hello');
       assert.strictEqual(line.indentTokens.length, 1);
       assert.strictEqual(line.indentTokens[0].type, 'dedent');
     });
 
     it('should parse multiple dedent tokens on same line', () => {
-      const result = parse('⟨1,0⟩⇤⟨1,0⟩⇤hello\n');
+      const result = parse('⟨1,0⟩⇤⟨1,0⟩⇤\n');
       assert.strictEqual(result.succeeded, true);
       assert.strictEqual(result.lines.length, 1);
       assert.strictEqual(result.lines[0].indentTokens.length, 2);
@@ -142,92 +123,37 @@ describe('grammar', () => {
     });
 
     it('should parse complex indentation sequence', () => {
-      const input = [
-        'root',
-        '⟨2,1⟩⇥child1',
-        '⟨3,2⟩⇥grandchild',
-        '⟨4,0⟩⇤⟨4,0⟩⇤sibling',
-        '',
-      ].join('\n');
+      const input = ['⟨1,1⟩⇥', '⟨2,2⟩⇥', '⟨3,0⟩⇤⟨3,0⟩⇤', ''].join('\n');
 
       const result = parse(input);
       assert.strictEqual(result.succeeded, true);
-      assert.strictEqual(result.lines.length, 4);
+      assert.strictEqual(result.lines.length, 3);
 
-      // root - no indent
-      assert.strictEqual(result.lines[0].segments[0].content, 'root');
-      assert.strictEqual(result.lines[0].indentTokens.length, 0);
+      // Line 1 - one INDENT (level 1)
+      assert.strictEqual(result.lines[0].indentTokens.length, 1);
+      assert.strictEqual(result.lines[0].indentTokens[0].type, 'indent');
+      assert.strictEqual(result.lines[0].indentTokens[0].position.level, 1);
 
-      // child1 - one INDENT (level 1)
-      assert.strictEqual(result.lines[1].segments[0].content, 'child1');
-      assert.strictEqual(result.lines[1].indentTokens.length, 1);
-      assert.strictEqual(result.lines[1].indentTokens[0].type, 'indent');
-      assert.strictEqual(result.lines[1].indentTokens[0].position.level, 1);
+      // Line 2 - one more INDENT (level 2)
+      assert.strictEqual(result.lines[1].indentTokens[0].position.level, 2);
 
-      // grandchild - one more INDENT (level 2)
-      assert.strictEqual(result.lines[2].segments[0].content, 'grandchild');
-      assert.strictEqual(result.lines[2].indentTokens[0].position.level, 2);
-
-      // sibling - two DEDENTs
-      assert.strictEqual(result.lines[3].segments[0].content, 'sibling');
-      assert.strictEqual(result.lines[3].indentTokens.length, 2);
+      // Line 3 - two DEDENTs
+      assert.strictEqual(result.lines[2].indentTokens.length, 2);
     });
-  });
 
-  describe('comment parsing', () => {
-    it('should parse full line comment', () => {
-      const result = parse('# this is a comment\n');
+    it('should skip comments (not in AST)', () => {
+      // Comments are treated as whitespace, so lines with only comments are blank
+      const result = parse('# just a comment\n');
+      assert.strictEqual(result.succeeded, true);
+      assert.strictEqual(result.lines.length, 0); // comment-only line is blank
+    });
+
+    it('should parse indent token with comments around it', () => {
+      const result = parse('# comment # ⟨1,1⟩⇥ # trailing\n');
       assert.strictEqual(result.succeeded, true);
       assert.strictEqual(result.lines.length, 1);
-      assert.strictEqual(result.lines[0].segments.length, 1);
-      assert.strictEqual(result.lines[0].segments[0].type, 'comment');
-      assert.strictEqual(result.lines[0].segments[0].content, ' this is a comment');
-    });
-
-    it('should parse inline toggle comment', () => {
-      const result = parse('text # comment # more\n');
-      assert.strictEqual(result.succeeded, true);
-      assert.strictEqual(result.lines[0].segments.length, 3);
-      assert.strictEqual(result.lines[0].segments[0].type, 'text');
-      assert.strictEqual(result.lines[0].segments[0].content, 'text ');
-      assert.strictEqual(result.lines[0].segments[1].type, 'comment');
-      assert.strictEqual(result.lines[0].segments[1].content, ' comment ');
-      assert.strictEqual(result.lines[0].segments[2].type, 'text');
-      assert.strictEqual(result.lines[0].segments[2].content, ' more');
-    });
-
-    it('should parse empty comment (##)', () => {
-      const result = parse('##\n');
-      assert.strictEqual(result.succeeded, true);
-      assert.strictEqual(result.lines[0].segments.length, 1);
-      assert.strictEqual(result.lines[0].segments[0].type, 'comment');
-      assert.strictEqual(result.lines[0].segments[0].content, '');
-    });
-
-    it('should parse multiple inline toggles', () => {
-      // a # b # c # d → text, comment, text, comment
-      const result = parse('a # b # c # d\n');
-      assert.strictEqual(result.succeeded, true);
-      assert.strictEqual(result.lines[0].segments.length, 4);
-      assert.strictEqual(result.lines[0].segments[0].type, 'text');
-      assert.strictEqual(result.lines[0].segments[1].type, 'comment');
-      assert.strictEqual(result.lines[0].segments[2].type, 'text');
-      assert.strictEqual(result.lines[0].segments[3].type, 'comment');
-    });
-
-    it('should parse comment with indentation', () => {
-      const result = parse('⟨1,1⟩⇥# indented comment\n');
-      assert.strictEqual(result.succeeded, true);
       assert.strictEqual(result.lines[0].indentTokens.length, 1);
-      assert.strictEqual(result.lines[0].segments[0].type, 'comment');
-      assert.strictEqual(result.lines[0].segments[0].content, ' indented comment');
-    });
-
-    it('should parse comment before dedent', () => {
-      const result = parse('text # comment\n⟨2,0⟩⇤back\n');
-      assert.strictEqual(result.succeeded, true);
-      assert.strictEqual(result.lines.length, 2);
-      assert.strictEqual(result.lines[0].segments[1].type, 'comment');
+      assert.strictEqual(result.lines[0].indentTokens[0].type, 'indent');
     });
   });
 
@@ -246,8 +172,8 @@ describe('grammar', () => {
       const token: IndentToken = sem(matchResult).toIndentToken();
       assert.strictEqual(token.type, 'indent');
       assert.deepStrictEqual(token.position, {
-        line: 5,
         level: 2,
+        line: 5,
       });
     });
 
@@ -272,20 +198,15 @@ describe('grammar', () => {
       const result = parse(preprocessed);
       assert.strictEqual(result.succeeded, true);
 
-      const contentLines = result.lines.filter(l => l.segments.length > 0);
-      assert.strictEqual(contentLines.length, 3);
-
-      // First line - no indent, comment
-      assert.strictEqual(contentLines[0].indentTokens.length, 0);
-      assert.strictEqual(contentLines[0].segments[0].type, 'comment');
-
-      // Second line - one INDENT
-      assert.strictEqual(contentLines[1].indentTokens.length, 1);
-      assert.strictEqual(contentLines[1].indentTokens[0].type, 'indent');
-
-      // Third line - one more INDENT
-      assert.strictEqual(contentLines[2].indentTokens.length, 1);
-      assert.strictEqual(contentLines[2].indentTokens[0].type, 'indent');
+      // Comments are skipped, so we only see indent structure
+      // Line 1: no indent (comment skipped)
+      // Line 2: INDENT to level 1
+      // Line 3: INDENT to level 2
+      // EOF: DEDENTs back to 0
+      const indentLines = result.lines.filter((l) =>
+        l.indentTokens.some((t) => t.type === 'indent')
+      );
+      assert.strictEqual(indentLines.length, 2);
     });
 
     it('should parse preprocessed space-indented file', async () => {
@@ -296,12 +217,12 @@ describe('grammar', () => {
       const result = parse(preprocessed);
       assert.strictEqual(result.succeeded, true);
 
-      const contentLines = result.lines.filter(l => l.segments.length > 0);
-      assert.strictEqual(contentLines.length, 3);
-
       // Check INDENT positions encode indent levels
-      assert.strictEqual(contentLines[1].indentTokens[0].position.level, 1);
-      assert.strictEqual(contentLines[2].indentTokens[0].position.level, 2);
+      const indentLines = result.lines.filter((l) =>
+        l.indentTokens.some((t) => t.type === 'indent')
+      );
+      assert.strictEqual(indentLines[0].indentTokens[0].position.level, 1);
+      assert.strictEqual(indentLines[1].indentTokens[0].position.level, 2);
     });
 
     it('should handle file with no indentation', async () => {
@@ -311,8 +232,8 @@ describe('grammar', () => {
 
       const result = parse(preprocessed);
       assert.strictEqual(result.succeeded, true);
-      assert.strictEqual(result.lines.length, 3);
-      assert.ok(result.lines.every(l => l.indentTokens.length === 0));
+      // All comment-only lines become blank
+      assert.strictEqual(result.lines.length, 0);
     });
 
     it('should handle empty file', async () => {
@@ -337,8 +258,8 @@ describe('grammar', () => {
       assert.strictEqual(result.succeeded, true);
 
       // Find lines with DEDENT tokens
-      const dedentLines = result.lines.filter(
-        l => l.indentTokens.some(t => t.type === 'dedent')
+      const dedentLines = result.lines.filter((l) =>
+        l.indentTokens.some((t) => t.type === 'dedent')
       );
       assert.ok(dedentLines.length > 0);
     });
@@ -351,35 +272,40 @@ describe('grammar', () => {
       const result = parse(preprocessed);
       assert.strictEqual(result.succeeded, true);
 
-      // Find lines with root2 content (has DEDENT)
-      const hasRoot2 = result.lines.some(l =>
-        l.segments.some(s => s.content.includes('root2')) &&
-        l.indentTokens.some(t => t.type === 'dedent')
+      // Should have a DEDENT line
+      const dedentLines = result.lines.filter((l) =>
+        l.indentTokens.some((t) => t.type === 'dedent')
       );
-      assert.ok(hasRoot2);
+      assert.ok(dedentLines.length > 0);
     });
   });
 
   describe('edge cases', () => {
     it('should handle multiple blank lines', () => {
-      const result = parse('\n\n\n# hello\n\n\n');
+      const result = parse('\n\n\n⟨4,1⟩⇥\n\n\n');
       assert.strictEqual(result.succeeded, true);
-      const nonBlank = result.lines.filter(l => l.segments.length > 0);
+      const nonBlank = result.lines.filter((l) => l.indentTokens.length > 0);
       assert.strictEqual(nonBlank.length, 1);
     });
 
     it('should handle input without trailing newline', () => {
-      const result = parse('hello');
+      const result = parse('⟨1,1⟩⇥');
       assert.strictEqual(result.succeeded, true);
       assert.strictEqual(result.lines.length, 1);
-      assert.strictEqual(result.lines[0].segments[0].content, 'hello');
     });
 
     it('should handle large position numbers', () => {
-      const result = parse('⟨999,100⟩⇥content\n');
+      const result = parse('⟨999,100⟩⇥\n');
       assert.strictEqual(result.succeeded, true);
       assert.strictEqual(result.lines[0].indentTokens[0].position.line, 999);
       assert.strictEqual(result.lines[0].indentTokens[0].position.level, 100);
+    });
+
+    it('should handle comment-only lines as blank', () => {
+      // A line with only comments should be treated as blank
+      const result = parse('# comment 1 # # comment 2 #\n');
+      assert.strictEqual(result.succeeded, true);
+      assert.strictEqual(result.lines.length, 0);
     });
   });
 });

--- a/packages/compiler/test/preprocessor.test.ts
+++ b/packages/compiler/test/preprocessor.test.ts
@@ -1,10 +1,10 @@
-import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { createReadStream } from 'node:fs';
-import { Readable } from 'node:stream';
-import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { preprocess, IndentationError } from '../src/preprocessor/index.ts';
+import { Readable } from 'node:stream';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { type IndentationError, preprocess } from '../src/preprocessor/index.ts';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -85,7 +85,7 @@ describe('preprocessor', () => {
       const result = await preprocess(stream);
       // Should have DEDENT at end to close the indent
       const lines = result.split('\n');
-      const lastNonEmpty = lines.filter(l => l.length > 0).pop();
+      const lastNonEmpty = lines.filter((l) => l.length > 0).pop();
       assert.ok(lastNonEmpty?.includes('⇤'));
     });
 


### PR DESCRIPTION
 - Use PascalCase for syntactic rules to auto-skip whitespace/comments
  - Remove terminator, newline, BlankLine rules (newlines are just whitespace)
  - Remove Text, Segment types (comments treated as whitespace, not AST nodes)
  - Simplify ParsedLine to just {indentTokens, lineNumber}
  - Replace ohm.grammars() with ohm.grammar() for single grammar
  - Extend space rule with comments instead of parsing them explicitly

  The grammar now focuses purely on indentation structure. Everything else
  (whitespace, newlines, comments) is automatically skipped between tokens,
  following the idiomatic Ohm-js approach for line-oriented languages.

  BREAKING CHANGE: ParsedLine no longer has segments property, Segment and
  SegmentType types removed, grammars export removed