### PR TITLE
refactor: apply idiomatic TypeScript and Node.js patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"author": "",
 	"description": "A programming language with compiler, CLI, and LSP server",
+	"type": "module",
 	"devDependencies": {
 		"@biomejs/biome": "2.3.8"
 	},

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,8 +14,8 @@
 	},
 	"exports": {
 		".": {
-			"default": "./dist/index.js",
-			"types": "./dist/index.d.ts"
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
 		}
 	},
 	"files": [

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,39 +5,37 @@ import BuildCommand from './commands/build.js'
 
 const version = '0.0.0'
 
-async function main(): Promise<void> {
-	const kernel = Kernel.create()
+const kernel = Kernel.create()
 
-	kernel.info.set('binary', 'tinywhale')
-	kernel.info.set('version', version)
+kernel.info.set('binary', 'tinywhale')
+kernel.info.set('version', version)
 
-	kernel.defineFlag('help', {
-		alias: 'h',
-		description: 'Display help information',
-		type: 'boolean',
-	})
+kernel.defineFlag('help', {
+	alias: 'h',
+	description: 'Display help information',
+	type: 'boolean',
+})
 
-	kernel.defineFlag('version', {
-		alias: 'v',
-		description: 'Display version number',
-		type: 'boolean',
-	})
+kernel.defineFlag('version', {
+	alias: 'v',
+	description: 'Display version number',
+	type: 'boolean',
+})
 
-	kernel.addLoader(new ListLoader([BuildCommand, HelpCommand]))
+kernel.addLoader(new ListLoader([BuildCommand, HelpCommand]))
 
-	kernel.on('finding:command', async () => {
-		console.log(`TinyWhale v${version}`)
-		console.log('')
-		console.log('Usage: tinywhale [command] [options]')
-		console.log('')
-		console.log('Run "tinywhale --help" for available commands and options.')
-		return true
-	})
+kernel.on('finding:command', async () => {
+	console.log(`TinyWhale v${version}`)
+	console.log('')
+	console.log('Usage: tinywhale [command] [options]')
+	console.log('')
+	console.log('Run "tinywhale --help" for available commands and options.')
+	return true
+})
 
+try {
 	await kernel.handle(process.argv.slice(2))
-}
-
-main().catch((error: unknown) => {
+} catch (error: unknown) {
 	console.error(error)
 	process.exit(1)
-})
+}

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -11,8 +11,8 @@
 	},
 	"exports": {
 		".": {
-			"default": "./dist/index.js",
-			"types": "./dist/index.d.ts"
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
 		}
 	},
 	"files": [

--- a/packages/compiler/src/grammar/index.ts
+++ b/packages/compiler/src/grammar/index.ts
@@ -114,9 +114,10 @@ export function createSemantics() {
 	semantics.addOperation<ParsedLine>('toLine', {
 		DedentLine(dedentTokens) {
 			const tokens: IndentToken[] = dedentTokens.children.map((t) => t.toIndentToken())
+			const firstToken = tokens[0]
 			return {
 				indentTokens: tokens,
-				lineNumber: tokens.length > 0 ? tokens[0].position.line : getLineNumber(this),
+				lineNumber: firstToken !== undefined ? firstToken.position.line : getLineNumber(this),
 			}
 		},
 		IndentedLine(indentToken) {

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -22,4 +22,4 @@ export {
 	type IndentMode,
 	type PreprocessOptions,
 	preprocess,
-} from './preprocessor/index.js'
+} from './preprocessor/index.ts'

--- a/packages/compiler/test/preprocessor.test.ts
+++ b/packages/compiler/test/preprocessor.test.ts
@@ -1,16 +1,12 @@
 import assert from 'node:assert'
 import { createReadStream } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { join } from 'node:path'
 import { Readable } from 'node:stream'
 import { describe, it } from 'node:test'
-import { fileURLToPath } from 'node:url'
 import { type IndentationError, preprocess } from '../src/preprocessor/index.ts'
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-
 function fixturesPath(name: string): string {
-	return join(__dirname, 'fixtures', name)
+	return join(import.meta.dirname, 'fixtures', name)
 }
 
 function streamFromString(text: string): Readable {

--- a/packages/lsp/package.json
+++ b/packages/lsp/package.json
@@ -7,6 +7,12 @@
 		"@tinywhale/compiler": "workspace:*"
 	},
 	"description": "TinyWhale Language Server Protocol implementation",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		}
+	},
 	"files": [
 		"dist"
 	],
@@ -23,6 +29,7 @@
 		"clean": "rm -rf dist",
 		"test": "echo 'Test script not yet configured'"
 	},
+	"type": "module",
 	"types": "./dist/index.d.ts",
 	"version": "0.0.0"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,12 +11,14 @@
 		"moduleResolution": "NodeNext",
 		"noFallthroughCasesInSwitch": true,
 		"noImplicitReturns": true,
+		"noUncheckedIndexedAccess": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
-		"target": "ESNext"
+		"target": "ESNext",
+		"verbatimModuleSyntax": true
 	}
 }


### PR DESCRIPTION
- Enable stricter TypeScript options: noUncheckedIndexedAccess and verbatimModuleSyntax
- Add proper error type guards instead of type assertions
- Use top-level await instead of async wrapper with .catch()
- Replace manual __dirname calculation with import.meta.dirname
- Ensure consistent ESM configuration across all packages
- Reorder exports to place types before default