### PR TITLE
refactor(compiler): modularize preprocessor

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -33,6 +33,12 @@
 		"enabled": true,
 		"rules": {
 			"complexity": {
+				"noExcessiveCognitiveComplexity": {
+					"level": "error",
+					"options": {
+						"maxAllowedComplexity": 4
+					}
+				},
 				"useLiteralKeys": "off"
 			},
 			"recommended": true

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -28,7 +28,7 @@
 	"scripts": {
 		"build": "tsc -p tsconfig.build.json",
 		"clean": "rm -rf dist",
-		"test": "node --test test/**/*.test.ts"
+		"test": "node --test test/*.test.ts test/preprocessor/*.test.ts"
 	},
 	"type": "module",
 	"types": "./dist/index.d.ts",

--- a/packages/compiler/src/preprocessor/analysis.ts
+++ b/packages/compiler/src/preprocessor/analysis.ts
@@ -1,0 +1,37 @@
+import type { IndentType, LineIndentInfo } from './types.ts'
+import { classifyWhitespace, updateIndentType } from './whitespace.ts'
+
+/**
+ * Analyzes a line's leading whitespace.
+ * Throws IndentationError if mixed indentation is found on the same line.
+ */
+export function analyzeLineIndent(line: string, lineNumber: number): LineIndentInfo {
+	if (line.length === 0) {
+		return { count: 0, type: null }
+	}
+
+	let indentEnd = 0
+	let indentType: IndentType | null = null
+
+	while (indentEnd < line.length) {
+		const charType = classifyWhitespace(line.charAt(indentEnd))
+		if (charType === null) break
+
+		indentType = updateIndentType(indentType, charType, lineNumber, indentEnd + 1)
+		indentEnd++
+	}
+
+	return { count: indentEnd, type: indentType }
+}
+
+/**
+ * Parses a "use spaces" directive from a line.
+ * Returns 'space' if directive found, null otherwise.
+ */
+export function parseDirective(line: string): IndentType | null {
+	const trimmed = line.trim()
+	if (trimmed === '"use spaces"' || trimmed === "'use spaces'") {
+		return 'space'
+	}
+	return null
+}

--- a/packages/compiler/src/preprocessor/errors.ts
+++ b/packages/compiler/src/preprocessor/errors.ts
@@ -1,0 +1,80 @@
+import type { ProcessingState } from './state.ts'
+import type { IndentType } from './types.ts'
+
+/**
+ * Error thrown when mixed indentation is detected.
+ */
+export class IndentationError extends Error {
+	readonly line: number
+	readonly column: number
+	readonly expected: IndentType
+	readonly found: IndentType
+
+	constructor(
+		message: string,
+		line: number,
+		column: number,
+		expected: IndentType,
+		found: IndentType
+	) {
+		super(message)
+		this.name = 'IndentationError'
+		this.line = line
+		this.column = column
+		this.expected = expected
+		this.found = found
+	}
+}
+
+/**
+ * Throws a mixed indentation error with appropriate message.
+ */
+export function throwMixedIndentError(
+	lineNumber: number,
+	column: number,
+	expected: IndentType,
+	found: IndentType
+): never {
+	const expectedName = expected === 'tab' ? 'tabs' : 'spaces'
+	const foundName = found === 'tab' ? 'tab' : 'space'
+	throw new IndentationError(
+		`${lineNumber}:${column} Mixed indentation: found ${foundName} after ${expectedName}. Use ${expectedName} only for indentation on this line.`,
+		lineNumber,
+		column,
+		expected,
+		found
+	)
+}
+
+/**
+ * Builds context message for indentation mismatch errors.
+ */
+export function buildIndentContextMessage(plural: string, state: ProcessingState): string {
+	if (state.indentEstablishedAt?.source === 'directive') {
+		return state.indentEstablishedAt.line === 0
+			? `File uses ${plural} by default (no "use spaces" directive at the top of file found).`
+			: `File uses ${plural} ("use spaces" directive on line ${state.indentEstablishedAt.line}).`
+	}
+	return `File uses ${plural} (first indented line: ${state.indentEstablishedAt?.line}).`
+}
+
+/**
+ * Throws an indentation mismatch error.
+ */
+export function throwIndentMismatchError(
+	lineNumber: number,
+	expected: IndentType,
+	found: IndentType,
+	state: ProcessingState
+): never {
+	const plural = expected === 'tab' ? 'tabs' : 'spaces'
+	const foundPlural = found === 'tab' ? 'tabs' : 'spaces'
+	const context = buildIndentContextMessage(plural, state)
+	throw new IndentationError(
+		`${lineNumber}:1 Unexpected ${foundPlural}. ${context} Convert this line to use ${plural}.`,
+		lineNumber,
+		1,
+		expected,
+		found
+	)
+}

--- a/packages/compiler/src/preprocessor/state.ts
+++ b/packages/compiler/src/preprocessor/state.ts
@@ -1,0 +1,37 @@
+import type { IndentMode, IndentType, LineIndentInfo } from './types.ts'
+
+/**
+ * State tracked during streaming processing.
+ */
+export interface ProcessingState {
+	mode: IndentMode
+	lineNumber: number
+	expectedIndentType: IndentType | null
+	indentEstablishedAt: { line: number; source: 'directive' | 'detected' } | null
+	directiveLine: number | null
+	bufferedLines: { line: string; lineNumber: number; indentInfo: LineIndentInfo }[]
+	directiveFound: boolean
+	isFirstChunk: boolean
+	previousLevel: number
+	previousSpaces: number
+	indentUnit: number | null
+}
+
+/**
+ * Creates initial processing state for the given mode.
+ */
+export function createProcessingState(mode: IndentMode): ProcessingState {
+	return {
+		bufferedLines: [],
+		directiveFound: false,
+		directiveLine: null,
+		expectedIndentType: mode === 'directive' ? 'tab' : null,
+		indentEstablishedAt: mode === 'directive' ? { line: 0, source: 'directive' } : null,
+		indentUnit: null,
+		isFirstChunk: true,
+		lineNumber: 0,
+		mode,
+		previousLevel: 0,
+		previousSpaces: 0,
+	}
+}

--- a/packages/compiler/src/preprocessor/tokens.ts
+++ b/packages/compiler/src/preprocessor/tokens.ts
@@ -1,0 +1,28 @@
+import type { Position } from './types.ts'
+
+/**
+ * Unicode characters for INDENT and DEDENT tokens.
+ */
+export const INDENT_CHAR = '⇥' // U+21E5 RIGHTWARDS ARROW TO BAR
+export const DEDENT_CHAR = '⇤' // U+21E4 LEFTWARDS ARROW TO BAR
+
+/**
+ * Creates a position string in the format ⟨line,level⟩
+ */
+export function formatPosition(pos: Position): string {
+	return `⟨${pos.line},${pos.level}⟩`
+}
+
+/**
+ * Creates an INDENT token with position.
+ */
+export function createIndentToken(pos: Position): string {
+	return `${formatPosition(pos)}${INDENT_CHAR}`
+}
+
+/**
+ * Creates a DEDENT token with position.
+ */
+export function createDedentToken(pos: Position): string {
+	return `${formatPosition(pos)}${DEDENT_CHAR}`
+}

--- a/packages/compiler/src/preprocessor/types.ts
+++ b/packages/compiler/src/preprocessor/types.ts
@@ -1,0 +1,35 @@
+/**
+ * Token types for indentation.
+ */
+export type IndentType = 'tab' | 'space'
+
+/**
+ * Indentation mode for the preprocessor.
+ * - 'detect': First indentation character encountered sets the file-wide type (default)
+ * - 'directive': Respects "use spaces" directive, otherwise defaults to tabs
+ */
+export type IndentMode = 'detect' | 'directive'
+
+/**
+ * Options for the preprocessor.
+ */
+export interface PreprocessOptions {
+	mode?: IndentMode
+}
+
+/**
+ * Represents a position in the source text.
+ * Line is 1-indexed. Level is the indent level (0 = root).
+ */
+export interface Position {
+	line: number
+	level: number
+}
+
+/**
+ * Result of analyzing a line's indentation.
+ */
+export interface LineIndentInfo {
+	type: IndentType | null
+	count: number
+}

--- a/packages/compiler/src/preprocessor/validation.ts
+++ b/packages/compiler/src/preprocessor/validation.ts
@@ -1,0 +1,105 @@
+import { IndentationError, throwIndentMismatchError } from './errors.ts'
+import type { ProcessingState } from './state.ts'
+import type { LineIndentInfo } from './types.ts'
+
+/**
+ * Validates indentation consistency and throws if mismatched.
+ */
+export function validateIndent(
+	indentInfo: LineIndentInfo,
+	lineNumber: number,
+	state: ProcessingState
+): void {
+	if (indentInfo.type === null) {
+		return
+	}
+
+	if (state.expectedIndentType === null) {
+		state.expectedIndentType = indentInfo.type
+		state.indentEstablishedAt = { line: lineNumber, source: 'detected' }
+	} else if (indentInfo.type !== state.expectedIndentType) {
+		throwIndentMismatchError(lineNumber, state.expectedIndentType, indentInfo.type, state)
+	}
+}
+
+/**
+ * Validates and sets the space indent unit on first indent, or checks consistency.
+ */
+export function validateSpaceIndent(
+	delta: number,
+	lineNumber: number,
+	state: ProcessingState
+): void {
+	if (state.indentUnit === null) {
+		state.indentUnit = delta
+	} else if (delta !== state.indentUnit) {
+		throw new IndentationError(
+			`${lineNumber}:1 File uses ${state.indentUnit}-space indentation. Add ${state.indentUnit} spaces, not ${delta}.`,
+			lineNumber,
+			1,
+			'space',
+			'space'
+		)
+	}
+}
+
+/**
+ * Validates that a space-based dedent aligns to a valid level.
+ */
+export function validateSpaceDedent(
+	indentInfo: LineIndentInfo,
+	lineNumber: number,
+	state: ProcessingState
+): void {
+	if (state.indentUnit === null) return
+	if (indentInfo.count % state.indentUnit === 0) return
+
+	const validLevels: number[] = []
+	for (let s = 0; s <= state.previousSpaces; s += state.indentUnit) {
+		validLevels.push(s)
+	}
+	throw new IndentationError(
+		`${lineNumber}:1 Unindent to ${validLevels.join(', ')} spaces.`,
+		lineNumber,
+		1,
+		'space',
+		'space'
+	)
+}
+
+/**
+ * Handles indent/dedent delta validation for space-based indentation.
+ */
+export function handleSpaceIndentDelta(
+	indentInfo: LineIndentInfo,
+	lineNumber: number,
+	state: ProcessingState
+): void {
+	const delta = indentInfo.count - state.previousSpaces
+	if (delta > 0) {
+		validateSpaceIndent(delta, lineNumber, state)
+	} else if (delta < 0) {
+		validateSpaceDedent(indentInfo, lineNumber, state)
+	}
+}
+
+/**
+ * Validates that indent doesn't jump more than one level.
+ */
+export function validateIndentJump(
+	newLevel: number,
+	previousLevel: number,
+	lineNumber: number,
+	indentInfo: LineIndentInfo
+): void {
+	if (newLevel <= previousLevel + 1) return
+	const expected = previousLevel + 1
+	const unit = indentInfo.type === 'tab' ? 'tab' : 'spaces'
+	throw new IndentationError(
+		`${lineNumber}:1 Use ${expected} ${unit}, not ${newLevel}.`,
+		lineNumber,
+		1,
+		indentInfo.type || 'tab',
+		indentInfo.type || 'tab'
+	)
+}

--- a/packages/compiler/src/preprocessor/whitespace.ts
+++ b/packages/compiler/src/preprocessor/whitespace.ts
@@ -1,0 +1,25 @@
+import { throwMixedIndentError } from './errors.ts'
+import type { IndentType } from './types.ts'
+
+/**
+ * Classifies a character as tab, space, or neither.
+ */
+export function classifyWhitespace(char: string): IndentType | null {
+	if (char === '\t') return 'tab'
+	if (char === ' ') return 'space'
+	return null
+}
+
+/**
+ * Updates indent type, throwing if mixed indentation detected.
+ */
+export function updateIndentType(
+	current: IndentType | null,
+	found: IndentType,
+	lineNumber: number,
+	column: number
+): IndentType {
+	if (current === null) return found
+	if (found !== current) throwMixedIndentError(lineNumber, column, current, found)
+	return current
+}

--- a/packages/compiler/test/preprocessor/analysis.test.ts
+++ b/packages/compiler/test/preprocessor/analysis.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { analyzeLineIndent, parseDirective } from '../../src/preprocessor/analysis.ts'
+
+describe('analysis', () => {
+	describe('analyzeLineIndent', () => {
+		it('should return count 0 for empty line', () => {
+			const result = analyzeLineIndent('', 1)
+			assert.deepStrictEqual(result, { count: 0, type: null })
+		})
+
+		it('should return count 0 for line with no indentation', () => {
+			const result = analyzeLineIndent('hello', 1)
+			assert.deepStrictEqual(result, { count: 0, type: null })
+		})
+
+		it('should count leading tabs', () => {
+			const result = analyzeLineIndent('\t\tfoo', 1)
+			assert.deepStrictEqual(result, { count: 2, type: 'tab' })
+		})
+
+		it('should count leading spaces', () => {
+			const result = analyzeLineIndent('    bar', 1)
+			assert.deepStrictEqual(result, { count: 4, type: 'space' })
+		})
+
+		it('should handle tab-only line', () => {
+			const result = analyzeLineIndent('\t', 1)
+			assert.deepStrictEqual(result, { count: 1, type: 'tab' })
+		})
+
+		it('should handle space-only line', () => {
+			const result = analyzeLineIndent('  ', 1)
+			assert.deepStrictEqual(result, { count: 2, type: 'space' })
+		})
+
+		it('should throw on mixed indentation (tab then space)', () => {
+			assert.throws(() => analyzeLineIndent('\t foo', 1), { name: 'IndentationError' })
+		})
+
+		it('should throw on mixed indentation (space then tab)', () => {
+			assert.throws(() => analyzeLineIndent(' \tfoo', 1), { name: 'IndentationError' })
+		})
+
+		it('should include line number in error', () => {
+			try {
+				analyzeLineIndent('\t foo', 42)
+				assert.fail('Should have thrown')
+			} catch (error) {
+				assert.strictEqual((error as { line: number }).line, 42)
+			}
+		})
+	})
+
+	describe('parseDirective', () => {
+		it('should parse double-quoted use spaces', () => {
+			assert.strictEqual(parseDirective('"use spaces"'), 'space')
+		})
+
+		it('should parse single-quoted use spaces', () => {
+			assert.strictEqual(parseDirective("'use spaces'"), 'space')
+		})
+
+		it('should handle leading/trailing whitespace', () => {
+			assert.strictEqual(parseDirective('  "use spaces"  '), 'space')
+		})
+
+		it('should return null for non-directive', () => {
+			assert.strictEqual(parseDirective('hello'), null)
+		})
+
+		it('should return null for partial match', () => {
+			assert.strictEqual(parseDirective('"use tabs"'), null)
+		})
+
+		it('should return null for empty string', () => {
+			assert.strictEqual(parseDirective(''), null)
+		})
+	})
+})

--- a/packages/compiler/test/preprocessor/errors.test.ts
+++ b/packages/compiler/test/preprocessor/errors.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import {
+	buildIndentContextMessage,
+	IndentationError,
+	throwIndentMismatchError,
+	throwMixedIndentError,
+} from '../../src/preprocessor/errors.ts'
+import type { ProcessingState } from '../../src/preprocessor/state.ts'
+
+function createMockState(overrides: Partial<ProcessingState> = {}): ProcessingState {
+	return {
+		bufferedLines: [],
+		directiveFound: false,
+		directiveLine: null,
+		expectedIndentType: null,
+		indentEstablishedAt: null,
+		indentUnit: null,
+		isFirstChunk: true,
+		lineNumber: 0,
+		mode: 'detect',
+		previousLevel: 0,
+		previousSpaces: 0,
+		...overrides,
+	}
+}
+
+describe('errors', () => {
+	describe('IndentationError', () => {
+		it('should create error with all properties', () => {
+			const error = new IndentationError('test message', 5, 3, 'tab', 'space')
+			assert.strictEqual(error.message, 'test message')
+			assert.strictEqual(error.name, 'IndentationError')
+			assert.strictEqual(error.line, 5)
+			assert.strictEqual(error.column, 3)
+			assert.strictEqual(error.expected, 'tab')
+			assert.strictEqual(error.found, 'space')
+		})
+
+		it('should be instance of Error', () => {
+			const error = new IndentationError('test', 1, 1, 'tab', 'space')
+			assert.ok(error instanceof Error)
+		})
+	})
+
+	describe('throwMixedIndentError', () => {
+		it('should throw IndentationError', () => {
+			assert.throws(() => throwMixedIndentError(1, 2, 'tab', 'space'), { name: 'IndentationError' })
+		})
+
+		it('should include line and column in error', () => {
+			try {
+				throwMixedIndentError(10, 5, 'tab', 'space')
+			} catch (error) {
+				const e = error as IndentationError
+				assert.strictEqual(e.line, 10)
+				assert.strictEqual(e.column, 5)
+			}
+		})
+
+		it('should include expected and found types', () => {
+			try {
+				throwMixedIndentError(1, 1, 'space', 'tab')
+			} catch (error) {
+				const e = error as IndentationError
+				assert.strictEqual(e.expected, 'space')
+				assert.strictEqual(e.found, 'tab')
+			}
+		})
+	})
+
+	describe('buildIndentContextMessage', () => {
+		it('should build message for default directive mode', () => {
+			const state = createMockState({
+				indentEstablishedAt: { line: 0, source: 'directive' },
+			})
+			const message = buildIndentContextMessage('tabs', state)
+			assert.ok(message.includes('by default'))
+		})
+
+		it('should build message for explicit directive', () => {
+			const state = createMockState({
+				indentEstablishedAt: { line: 5, source: 'directive' },
+			})
+			const message = buildIndentContextMessage('spaces', state)
+			assert.ok(message.includes('directive on line 5'))
+		})
+
+		it('should build message for detected indent', () => {
+			const state = createMockState({
+				indentEstablishedAt: { line: 3, source: 'detected' },
+			})
+			const message = buildIndentContextMessage('tabs', state)
+			assert.ok(message.includes('first indented line: 3'))
+		})
+	})
+
+	describe('throwIndentMismatchError', () => {
+		it('should throw IndentationError', () => {
+			const state = createMockState({
+				indentEstablishedAt: { line: 1, source: 'detected' },
+			})
+			assert.throws(() => throwIndentMismatchError(5, 'tab', 'space', state), {
+				name: 'IndentationError',
+			})
+		})
+
+		it('should include context in message', () => {
+			const state = createMockState({
+				indentEstablishedAt: { line: 2, source: 'detected' },
+			})
+			try {
+				throwIndentMismatchError(5, 'tab', 'space', state)
+			} catch (error) {
+				const e = error as IndentationError
+				assert.ok(e.message.includes('first indented line'))
+			}
+		})
+	})
+})

--- a/packages/compiler/test/preprocessor/state.test.ts
+++ b/packages/compiler/test/preprocessor/state.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { createProcessingState } from '../../src/preprocessor/state.ts'
+
+describe('state', () => {
+	describe('createProcessingState', () => {
+		it('should create detect mode state with null indent type', () => {
+			const state = createProcessingState('detect')
+			assert.strictEqual(state.mode, 'detect')
+			assert.strictEqual(state.expectedIndentType, null)
+			assert.strictEqual(state.indentEstablishedAt, null)
+		})
+
+		it('should create directive mode state with tab default', () => {
+			const state = createProcessingState('directive')
+			assert.strictEqual(state.mode, 'directive')
+			assert.strictEqual(state.expectedIndentType, 'tab')
+			assert.deepStrictEqual(state.indentEstablishedAt, { line: 0, source: 'directive' })
+		})
+
+		it('should initialize line number to 0', () => {
+			const state = createProcessingState('detect')
+			assert.strictEqual(state.lineNumber, 0)
+		})
+
+		it('should initialize empty buffered lines', () => {
+			const state = createProcessingState('detect')
+			assert.deepStrictEqual(state.bufferedLines, [])
+		})
+
+		it('should initialize isFirstChunk to true', () => {
+			const state = createProcessingState('detect')
+			assert.strictEqual(state.isFirstChunk, true)
+		})
+
+		it('should initialize previousLevel to 0', () => {
+			const state = createProcessingState('detect')
+			assert.strictEqual(state.previousLevel, 0)
+		})
+
+		it('should initialize previousSpaces to 0', () => {
+			const state = createProcessingState('detect')
+			assert.strictEqual(state.previousSpaces, 0)
+		})
+
+		it('should initialize indentUnit to null', () => {
+			const state = createProcessingState('detect')
+			assert.strictEqual(state.indentUnit, null)
+		})
+	})
+})

--- a/packages/compiler/test/preprocessor/tokens.test.ts
+++ b/packages/compiler/test/preprocessor/tokens.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import {
+	createDedentToken,
+	createIndentToken,
+	formatPosition,
+} from '../../src/preprocessor/tokens.ts'
+
+describe('tokens', () => {
+	describe('formatPosition', () => {
+		it('should format position as ⟨line,level⟩', () => {
+			assert.strictEqual(formatPosition({ level: 0, line: 1 }), '⟨1,0⟩')
+		})
+
+		it('should handle large numbers', () => {
+			assert.strictEqual(formatPosition({ level: 42, line: 999 }), '⟨999,42⟩')
+		})
+	})
+
+	describe('createIndentToken', () => {
+		it('should create INDENT token with position', () => {
+			assert.strictEqual(createIndentToken({ level: 1, line: 2 }), '⟨2,1⟩⇥')
+		})
+
+		it('should include arrow character', () => {
+			const token = createIndentToken({ level: 0, line: 1 })
+			assert.ok(token.includes('⇥'))
+		})
+	})
+
+	describe('createDedentToken', () => {
+		it('should create DEDENT token with position', () => {
+			assert.strictEqual(createDedentToken({ level: 0, line: 4 }), '⟨4,0⟩⇤')
+		})
+
+		it('should include arrow character', () => {
+			const token = createDedentToken({ level: 0, line: 1 })
+			assert.ok(token.includes('⇤'))
+		})
+	})
+})

--- a/packages/compiler/test/preprocessor/validation.test.ts
+++ b/packages/compiler/test/preprocessor/validation.test.ts
@@ -1,0 +1,155 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import type { ProcessingState } from '../../src/preprocessor/state.ts'
+import {
+	handleSpaceIndentDelta,
+	validateIndent,
+	validateIndentJump,
+	validateSpaceDedent,
+	validateSpaceIndent,
+} from '../../src/preprocessor/validation.ts'
+
+function createMockState(overrides: Partial<ProcessingState> = {}): ProcessingState {
+	return {
+		bufferedLines: [],
+		directiveFound: false,
+		directiveLine: null,
+		expectedIndentType: null,
+		indentEstablishedAt: null,
+		indentUnit: null,
+		isFirstChunk: true,
+		lineNumber: 0,
+		mode: 'detect',
+		previousLevel: 0,
+		previousSpaces: 0,
+		...overrides,
+	}
+}
+
+describe('validation', () => {
+	describe('validateIndent', () => {
+		it('should do nothing for null indent type', () => {
+			const state = createMockState()
+			validateIndent({ count: 0, type: null }, 1, state)
+			assert.strictEqual(state.expectedIndentType, null)
+		})
+
+		it('should establish indent type on first indented line', () => {
+			const state = createMockState()
+			validateIndent({ count: 1, type: 'tab' }, 2, state)
+			assert.strictEqual(state.expectedIndentType, 'tab')
+			assert.deepStrictEqual(state.indentEstablishedAt, { line: 2, source: 'detected' })
+		})
+
+		it('should allow matching indent type', () => {
+			const state = createMockState({
+				expectedIndentType: 'space',
+				indentEstablishedAt: { line: 1, source: 'detected' },
+			})
+			assert.doesNotThrow(() => {
+				validateIndent({ count: 2, type: 'space' }, 2, state)
+			})
+		})
+
+		it('should throw on mismatched indent type', () => {
+			const state = createMockState({
+				expectedIndentType: 'tab',
+				indentEstablishedAt: { line: 1, source: 'detected' },
+			})
+			assert.throws(() => validateIndent({ count: 2, type: 'space' }, 3, state), {
+				name: 'IndentationError',
+			})
+		})
+	})
+
+	describe('validateSpaceIndent', () => {
+		it('should set indent unit on first indent', () => {
+			const state = createMockState()
+			validateSpaceIndent(2, 1, state)
+			assert.strictEqual(state.indentUnit, 2)
+		})
+
+		it('should allow matching indent unit', () => {
+			const state = createMockState({ indentUnit: 4 })
+			assert.doesNotThrow(() => {
+				validateSpaceIndent(4, 2, state)
+			})
+		})
+
+		it('should throw on inconsistent indent unit', () => {
+			const state = createMockState({ indentUnit: 2 })
+			assert.throws(() => validateSpaceIndent(4, 3, state), { name: 'IndentationError' })
+		})
+	})
+
+	describe('validateSpaceDedent', () => {
+		it('should do nothing when indentUnit is null', () => {
+			const state = createMockState()
+			assert.doesNotThrow(() => {
+				validateSpaceDedent({ count: 3, type: 'space' }, 1, state)
+			})
+		})
+
+		it('should allow valid dedent (aligned to unit)', () => {
+			const state = createMockState({ indentUnit: 2, previousSpaces: 4 })
+			assert.doesNotThrow(() => {
+				validateSpaceDedent({ count: 2, type: 'space' }, 3, state)
+			})
+		})
+
+		it('should throw on misaligned dedent', () => {
+			const state = createMockState({ indentUnit: 2, previousSpaces: 4 })
+			assert.throws(() => validateSpaceDedent({ count: 3, type: 'space' }, 3, state), {
+				name: 'IndentationError',
+			})
+		})
+	})
+
+	describe('validateIndentJump', () => {
+		it('should allow single level increase', () => {
+			assert.doesNotThrow(() => {
+				validateIndentJump(1, 0, 2, { count: 1, type: 'tab' })
+			})
+		})
+
+		it('should allow same level', () => {
+			assert.doesNotThrow(() => {
+				validateIndentJump(2, 2, 3, { count: 2, type: 'tab' })
+			})
+		})
+
+		it('should allow decrease', () => {
+			assert.doesNotThrow(() => {
+				validateIndentJump(0, 3, 4, { count: 0, type: null })
+			})
+		})
+
+		it('should throw on multi-level jump', () => {
+			assert.throws(() => validateIndentJump(3, 1, 5, { count: 3, type: 'tab' }), {
+				name: 'IndentationError',
+			})
+		})
+	})
+
+	describe('handleSpaceIndentDelta', () => {
+		it('should call validateSpaceIndent for positive delta', () => {
+			const state = createMockState({ previousSpaces: 0 })
+			handleSpaceIndentDelta({ count: 2, type: 'space' }, 1, state)
+			assert.strictEqual(state.indentUnit, 2)
+		})
+
+		it('should call validateSpaceDedent for negative delta', () => {
+			const state = createMockState({ indentUnit: 2, previousSpaces: 4 })
+			assert.doesNotThrow(() => {
+				handleSpaceIndentDelta({ count: 2, type: 'space' }, 3, state)
+			})
+		})
+
+		it('should do nothing for zero delta', () => {
+			const state = createMockState({ previousSpaces: 4 })
+			assert.doesNotThrow(() => {
+				handleSpaceIndentDelta({ count: 4, type: 'space' }, 2, state)
+			})
+		})
+	})
+})

--- a/packages/compiler/test/preprocessor/whitespace.test.ts
+++ b/packages/compiler/test/preprocessor/whitespace.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { classifyWhitespace, updateIndentType } from '../../src/preprocessor/whitespace.ts'
+
+describe('whitespace', () => {
+	describe('classifyWhitespace', () => {
+		it('should return tab for tab character', () => {
+			assert.strictEqual(classifyWhitespace('\t'), 'tab')
+		})
+
+		it('should return space for space character', () => {
+			assert.strictEqual(classifyWhitespace(' '), 'space')
+		})
+
+		it('should return null for non-whitespace', () => {
+			assert.strictEqual(classifyWhitespace('a'), null)
+		})
+
+		it('should return null for empty string', () => {
+			assert.strictEqual(classifyWhitespace(''), null)
+		})
+
+		it('should return null for newline', () => {
+			assert.strictEqual(classifyWhitespace('\n'), null)
+		})
+	})
+
+	describe('updateIndentType', () => {
+		it('should return found type when current is null', () => {
+			assert.strictEqual(updateIndentType(null, 'tab', 1, 1), 'tab')
+			assert.strictEqual(updateIndentType(null, 'space', 1, 1), 'space')
+		})
+
+		it('should return current when types match', () => {
+			assert.strictEqual(updateIndentType('tab', 'tab', 1, 1), 'tab')
+			assert.strictEqual(updateIndentType('space', 'space', 1, 1), 'space')
+		})
+
+		it('should throw on mixed indentation', () => {
+			assert.throws(() => updateIndentType('tab', 'space', 1, 2), { name: 'IndentationError' })
+			assert.throws(() => updateIndentType('space', 'tab', 1, 3), { name: 'IndentationError' })
+		})
+	})
+})


### PR DESCRIPTION
- Split 570-line preprocessor into 7 focused modules
- Add cognitive complexity lint rule (max: 4)
- Extract formatReadError helper in CLI build command
- Add 64 unit tests for preprocessor modules (134 total)