### PR TITLE
feat(compiler): add panic keyword as reserved statement

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { HelpCommand, Kernel, ListLoader } from '@adonisjs/ace'
-import BuildCommand from './commands/build.js'
+import BuildCommand from './commands/build.ts'
 
 const version = '0.0.0'
 

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,10 +1,11 @@
 {
 	"compilerOptions": {
-		"allowImportingTsExtensions": false,
+		"allowImportingTsExtensions": true,
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
 		"noEmit": false,
 		"outDir": "./dist",
+		"rewriteRelativeImportExtensions": true,
 		"rootDir": "./src"
 	},
 	"exclude": ["node_modules", "dist"],

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -7,16 +7,19 @@ export {
 	type IndentInfo,
 	type IndentToken,
 	match,
+	type PanicStatementNode,
 	type ParsedLine,
 	type ParseResult,
 	type Position,
 	parse,
 	// Backwards compatibility
 	type SourcePosition,
+	type Statement,
+	type StatementNode,
 	semantics,
 	TinyWhaleGrammar,
 	trace,
-} from './grammar/index.js'
+} from './grammar/index.ts'
 export {
 	IndentationError,
 	type IndentMode,

--- a/packages/compiler/test/fixtures/panic.tw
+++ b/packages/compiler/test/fixtures/panic.tw
@@ -1,0 +1,5 @@
+# test file with panic keyword
+	panic
+		panic
+	panic
+# done

--- a/packages/compiler/test/preprocessor.test.ts
+++ b/packages/compiler/test/preprocessor.test.ts
@@ -367,5 +367,16 @@ describe('preprocessor', () => {
 				}
 			)
 		})
+
+		it('should process panic.tw fixture', async () => {
+			const stream = createReadStream(fixturesPath('panic.tw'), 'utf-8')
+			const result = await preprocess(stream)
+			// Should have INDENT tokens
+			assert.ok(result.includes('⇥'))
+			// Should have DEDENT tokens
+			assert.ok(result.includes('⇤'))
+			// Should have panic statements preserved
+			assert.ok(result.includes('panic'))
+		})
 	})
 })

--- a/packages/compiler/tsconfig.build.json
+++ b/packages/compiler/tsconfig.build.json
@@ -1,10 +1,11 @@
 {
 	"compilerOptions": {
-		"allowImportingTsExtensions": false,
+		"allowImportingTsExtensions": true,
 		"declaration": true,
 		"declarationMap": true,
 		"noEmit": false,
 		"outDir": "./dist",
+		"rewriteRelativeImportExtensions": true,
 		"rootDir": "./src"
 	},
 	"exclude": ["node_modules", "dist", "test"],


### PR DESCRIPTION
Add `panic` as a bare keyword statement to the TinyWhale grammar. This is a minimal incremental step - no arguments or WebAssembly compilation yet. Changes:
- Add StatementNode, PanicStatementNode, Statement types
- Update grammar with panic keyword rules using ~identifierPart for proper keyword protection
- Add toStatement semantic operation
- Update IndentedLine and DedentLine to accept optional statements
- Export new types from compiler package
- Add panic.tw test fixture
- Add comprehensive tests for panic keyword parsing

Also fixes TypeScript build configuration:
- Enable allowImportingTsExtensions and rewriteRelativeImportExtensions in both compiler and cli packages to support .ts imports with JS output