### PR TITLE
feat(compiler): add WebAssembly code generation

### DIFF
--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -9,5 +9,7 @@
 !README.md
 !src/
 !src/**
+!test/
+!test/**
 !tsconfig.build.json
 !tsconfig.json

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
 	"scripts": {
 		"build": "tsc -p tsconfig.build.json",
 		"clean": "rm -rf dist",
-		"test": "echo 'Test script not yet configured'",
+		"test": "node --test test/*.test.ts",
 		"typecheck": "tsc --noEmit"
 	},
 	"type": "module",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -24,7 +24,7 @@ kernel.defineFlag('version', {
 
 kernel.addLoader(new ListLoader([BuildCommand, HelpCommand]))
 
-kernel.on('finding:command', async () => {
+kernel.on('finding:command', async (): Promise<boolean> => {
 	console.log(`TinyWhale v${version}`)
 	console.log('')
 	console.log('Usage: tinywhale [command] [options]')

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,32 +1,39 @@
-import { readFile, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { Readable } from 'node:stream'
 import { args, BaseCommand, flags } from '@adonisjs/ace'
-import { IndentationError, parse, preprocess } from '@tinywhale/compiler'
-
-function isNodeError(error: unknown): error is NodeJS.ErrnoException {
-	return error instanceof Error && 'code' in error
-}
-
-function getErrorMessage(error: unknown): string {
-	return error instanceof Error ? error.message : String(error)
-}
-
-function formatReadError(filePath: string, error: unknown): string {
-	if (isNodeError(error) && error.code === 'ENOENT') {
-		return `File not found: ${filePath}`
-	}
-	return `Cannot read file: ${getErrorMessage(error)}`
-}
+import {
+	type CompileResult,
+	compile,
+	IndentationError,
+	type ParseResult,
+	parse,
+	preprocess,
+} from '@tinywhale/compiler'
+import {
+	formatCompileError,
+	formatReadError,
+	getErrorMessage,
+	getOutputContent,
+	isValidTarget,
+	type OutputTarget,
+	resolveOutputPath,
+} from '../utils.ts'
 
 export default class BuildCommand extends BaseCommand {
 	static override commandName = 'build'
-	static override description = 'Compile a TinyWhale source file and output the AST'
+	static override description = 'Compile a TinyWhale source file to WebAssembly'
 
 	@args.string({ description: 'Input .tw file to compile' })
 	declare input: string
 
-	@flags.string({ alias: 'o', description: 'Output file (defaults to stdout)' })
+	@flags.string({ alias: 'o', description: 'Output directory (created if not exists)' })
 	declare output?: string
+
+	@flags.string({ default: 'wasm', description: 'Output format: wasm (binary) or wat (text)' })
+	declare target: string
+
+	@flags.boolean({ description: 'Run optimization passes' })
+	declare optimize: boolean
 
 	private async readSourceFile(): Promise<string | null> {
 		try {
@@ -38,52 +45,104 @@ export default class BuildCommand extends BaseCommand {
 		}
 	}
 
+	private formatPreprocessError(error: unknown): string {
+		if (error instanceof IndentationError) {
+			return error.message
+		}
+		return `Preprocessing failed: ${getErrorMessage(error)}`
+	}
+
 	private async preprocessSource(source: string): Promise<string | null> {
 		try {
 			return await preprocess(Readable.from(source))
 		} catch (error: unknown) {
-			if (error instanceof IndentationError) {
-				this.logger.error(error.message)
-			} else {
-				this.logger.error(`Preprocessing failed: ${getErrorMessage(error)}`)
-			}
+			this.logger.error(this.formatPreprocessError(error))
 			this.exitCode = 1
 			return null
 		}
 	}
 
-	private async writeOutput(json: string): Promise<boolean> {
-		if (!this.output) {
-			console.log(json)
-			return true
+	private parseSource(preprocessed: string): ParseResult | null {
+		const parseResult = parse(preprocessed)
+		if (!parseResult.succeeded) {
+			this.logger.error(`Parse error: ${parseResult.message}`)
+			this.exitCode = 1
+			return null
 		}
+		return parseResult
+	}
+
+	private compileToWasm(parseResult: ParseResult): CompileResult | null {
 		try {
-			await writeFile(this.output, json, 'utf-8')
+			const result = compile(parseResult, { optimize: this.optimize })
+			if (!result.valid) {
+				this.logger.error('Generated WebAssembly module failed validation')
+				this.exitCode = 1
+				return null
+			}
+			return result
+		} catch (error: unknown) {
+			this.logger.error(formatCompileError(error))
+			this.exitCode = 1
+			return null
+		}
+	}
+
+	private validateTarget(): boolean {
+		if (!isValidTarget(this.target)) {
+			this.logger.error(`Invalid target "${this.target}". Use "wasm" or "wat".`)
+			this.exitCode = 1
+			return false
+		}
+		return true
+	}
+
+	private async writeOutputFile(
+		outputPath: string,
+		content: Uint8Array | string
+	): Promise<boolean> {
+		try {
+			await writeFile(outputPath, content)
 			return true
 		} catch (error: unknown) {
-			this.logger.error(`Cannot write to ${this.output}: ${getErrorMessage(error)}`)
+			this.logger.error(`Cannot write to ${outputPath}: ${getErrorMessage(error)}`)
 			return false
 		}
 	}
 
-	override async run(): Promise<void> {
-		const source = await this.readSourceFile()
-		if (source === null) return
+	private async emitOutput(result: CompileResult): Promise<void> {
+		const target = this.target as OutputTarget
+		const dir = this.output ?? '.'
 
-		const preprocessed = await this.preprocessSource(source)
-		if (preprocessed === null) return
+		await mkdir(dir, { recursive: true })
 
-		const result = parse(preprocessed)
-		const json = JSON.stringify(result, null, '\t')
-
-		const written = await this.writeOutput(json)
+		const outputPath = resolveOutputPath(this.input, this.output, target)
+		const content = getOutputContent(result, target)
+		const written = await this.writeOutputFile(outputPath, content)
 		if (!written) {
 			this.exitCode = 1
-			return
 		}
+	}
 
-		if (!result.succeeded) {
-			this.exitCode = 1
-		}
+	private async parseAndCompile(): Promise<CompileResult | null> {
+		const source = await this.readSourceFile()
+		if (source === null) return null
+
+		const preprocessed = await this.preprocessSource(source)
+		if (preprocessed === null) return null
+
+		const parseResult = this.parseSource(preprocessed)
+		if (parseResult === null) return null
+
+		return this.compileToWasm(parseResult)
+	}
+
+	override async run(): Promise<void> {
+		if (!this.validateTarget()) return
+
+		const result = await this.parseAndCompile()
+		if (result === null) return
+
+		await this.emitOutput(result)
 	}
 }

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -29,7 +29,7 @@ export default class BuildCommand extends BaseCommand {
 	@flags.string({ alias: 'o', description: 'Output directory (created if not exists)' })
 	declare output?: string
 
-	@flags.string({ default: 'wasm', description: 'Output format: wasm (binary) or wat (text)' })
+	@flags.string({ alias: 't', default: 'wasm', description: 'Output format: wasm (binary) or wat (text)' })
 	declare target: string
 
 	@flags.boolean({ description: 'Run optimization passes' })

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,0 +1,48 @@
+import { basename, join } from 'node:path'
+import { CompileError, type CompileResult } from '@tinywhale/compiler'
+
+export type OutputTarget = 'wasm' | 'wat'
+
+export function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error && 'code' in error
+}
+
+export function getErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error)
+}
+
+export function formatReadError(filePath: string, error: unknown): string {
+	if (isNodeError(error) && error.code === 'ENOENT') {
+		return `File not found: ${filePath}`
+	}
+	return `Cannot read file: ${getErrorMessage(error)}`
+}
+
+export function formatCompileError(error: unknown): string {
+	if (error instanceof CompileError) {
+		return error.message
+	}
+	return `Compilation failed: ${getErrorMessage(error)}`
+}
+
+export function isValidTarget(value: string): value is OutputTarget {
+	return value === 'wasm' || value === 'wat'
+}
+
+export function resolveOutputFilename(inputPath: string, target: OutputTarget): string {
+	return `${basename(inputPath, '.tw')}.${target}`
+}
+
+export function resolveOutputPath(
+	inputPath: string,
+	outputDir: string | undefined,
+	target: OutputTarget
+): string {
+	const filename = resolveOutputFilename(inputPath, target)
+	const dir = outputDir ?? '.'
+	return join(dir, filename)
+}
+
+export function getOutputContent(result: CompileResult, target: OutputTarget): Uint8Array | string {
+	return target === 'wat' ? result.text : result.binary
+}

--- a/packages/cli/test/utils.test.ts
+++ b/packages/cli/test/utils.test.ts
@@ -1,0 +1,163 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { CompileError } from '@tinywhale/compiler'
+import {
+	formatCompileError,
+	formatReadError,
+	getErrorMessage,
+	getOutputContent,
+	isNodeError,
+	isValidTarget,
+	resolveOutputFilename,
+	resolveOutputPath,
+} from '../src/utils.ts'
+
+describe('isNodeError', () => {
+	it('should return true for Error with code property', () => {
+		const error = new Error('test') as NodeJS.ErrnoException
+		error.code = 'ENOENT'
+		assert.strictEqual(isNodeError(error), true)
+	})
+
+	it('should return false for plain Error', () => {
+		const error = new Error('test')
+		assert.strictEqual(isNodeError(error), false)
+	})
+
+	it('should return false for non-Error', () => {
+		assert.strictEqual(isNodeError('string'), false)
+		assert.strictEqual(isNodeError(null), false)
+		assert.strictEqual(isNodeError(undefined), false)
+		assert.strictEqual(isNodeError(42), false)
+	})
+})
+
+describe('getErrorMessage', () => {
+	it('should extract message from Error', () => {
+		const error = new Error('test message')
+		assert.strictEqual(getErrorMessage(error), 'test message')
+	})
+
+	it('should convert non-Error to string', () => {
+		assert.strictEqual(getErrorMessage('string error'), 'string error')
+		assert.strictEqual(getErrorMessage(42), '42')
+		assert.strictEqual(getErrorMessage(null), 'null')
+	})
+})
+
+describe('formatReadError', () => {
+	it('should format ENOENT as "File not found"', () => {
+		const error = new Error('no such file') as NodeJS.ErrnoException
+		error.code = 'ENOENT'
+		const result = formatReadError('/path/to/file.tw', error)
+		assert.strictEqual(result, 'File not found: /path/to/file.tw')
+	})
+
+	it('should format other errors with generic message', () => {
+		const error = new Error('permission denied') as NodeJS.ErrnoException
+		error.code = 'EACCES'
+		const result = formatReadError('/path/to/file.tw', error)
+		assert.strictEqual(result, 'Cannot read file: permission denied')
+	})
+
+	it('should handle plain Error', () => {
+		const error = new Error('unknown error')
+		const result = formatReadError('/path/to/file.tw', error)
+		assert.strictEqual(result, 'Cannot read file: unknown error')
+	})
+})
+
+describe('formatCompileError', () => {
+	it('should return CompileError message directly', () => {
+		const error = new CompileError('Empty program')
+		const result = formatCompileError(error)
+		assert.strictEqual(result, 'Empty program')
+	})
+
+	it('should wrap other errors with "Compilation failed"', () => {
+		const error = new Error('something went wrong')
+		const result = formatCompileError(error)
+		assert.strictEqual(result, 'Compilation failed: something went wrong')
+	})
+
+	it('should handle non-Error values', () => {
+		const result = formatCompileError('string error')
+		assert.strictEqual(result, 'Compilation failed: string error')
+	})
+})
+
+describe('isValidTarget', () => {
+	it('should return true for "wasm"', () => {
+		assert.strictEqual(isValidTarget('wasm'), true)
+	})
+
+	it('should return true for "wat"', () => {
+		assert.strictEqual(isValidTarget('wat'), true)
+	})
+
+	it('should return false for other strings', () => {
+		assert.strictEqual(isValidTarget('txt'), false)
+		assert.strictEqual(isValidTarget('bin'), false)
+		assert.strictEqual(isValidTarget(''), false)
+		assert.strictEqual(isValidTarget('WASM'), false)
+	})
+})
+
+describe('resolveOutputFilename', () => {
+	it('should derive filename from input basename', () => {
+		assert.strictEqual(resolveOutputFilename('main.tw', 'wasm'), 'main.wasm')
+	})
+
+	it('should strip .tw extension', () => {
+		assert.strictEqual(resolveOutputFilename('program.tw', 'wat'), 'program.wat')
+	})
+
+	it('should add .wasm for wasm target', () => {
+		assert.strictEqual(resolveOutputFilename('test.tw', 'wasm'), 'test.wasm')
+	})
+
+	it('should add .wat for wat target', () => {
+		assert.strictEqual(resolveOutputFilename('test.tw', 'wat'), 'test.wat')
+	})
+
+	it('should handle paths with directories', () => {
+		assert.strictEqual(resolveOutputFilename('src/lib/main.tw', 'wasm'), 'main.wasm')
+		assert.strictEqual(resolveOutputFilename('/absolute/path/file.tw', 'wat'), 'file.wat')
+	})
+})
+
+describe('resolveOutputPath', () => {
+	it('should use current directory when output is undefined', () => {
+		assert.strictEqual(resolveOutputPath('main.tw', undefined, 'wasm'), 'main.wasm')
+	})
+
+	it('should join output directory with filename', () => {
+		assert.strictEqual(resolveOutputPath('main.tw', 'dist', 'wasm'), 'dist/main.wasm')
+	})
+
+	it('should handle nested output directories', () => {
+		assert.strictEqual(resolveOutputPath('main.tw', 'build/output', 'wat'), 'build/output/main.wat')
+	})
+
+	it('should extract basename from input path', () => {
+		assert.strictEqual(resolveOutputPath('src/main.tw', 'dist', 'wasm'), 'dist/main.wasm')
+	})
+})
+
+describe('getOutputContent', () => {
+	const mockResult = {
+		binary: new Uint8Array([0, 1, 2, 3]),
+		text: '(module)',
+		valid: true,
+	}
+
+	it('should return binary for wasm target', () => {
+		const result = getOutputContent(mockResult, 'wasm')
+		assert.strictEqual(result, mockResult.binary)
+	})
+
+	it('should return text for wat target', () => {
+		const result = getOutputContent(mockResult, 'wat')
+		assert.strictEqual(result, mockResult.text)
+	})
+})

--- a/packages/compiler/src/codegen/index.ts
+++ b/packages/compiler/src/codegen/index.ts
@@ -1,0 +1,108 @@
+import binaryen from 'binaryen'
+
+import type { ParseResult, Statement } from '../grammar/index.ts'
+
+/**
+ * Error thrown when compilation fails.
+ */
+export class CompileError extends Error {
+	constructor(message: string) {
+		super(message)
+		this.name = 'CompileError'
+	}
+}
+
+/**
+ * Options for the compile function.
+ */
+export interface CompileOptions {
+	/** Run Binaryen optimization passes (default: false) */
+	optimize?: boolean
+}
+
+/**
+ * Result of compiling a TinyWhale program to WebAssembly.
+ */
+export interface CompileResult {
+	/** The compiled WebAssembly binary */
+	binary: Uint8Array
+	/** The WebAssembly text format (WAT) representation */
+	text: string
+	/** Whether the module passed validation */
+	valid: boolean
+}
+
+function compileStatement(mod: binaryen.Module, stmt: Statement): binaryen.ExpressionRef {
+	switch (stmt.type) {
+		case 'panic':
+			return mod.unreachable()
+		default:
+			throw new CompileError(`Unknown statement type: ${(stmt as Statement).type}`)
+	}
+}
+
+function collectExpressions(
+	mod: binaryen.Module,
+	parseResult: ParseResult
+): binaryen.ExpressionRef[] {
+	const expressions: binaryen.ExpressionRef[] = []
+	for (const line of parseResult.lines) {
+		if (line.statement) {
+			expressions.push(compileStatement(mod, line.statement))
+		}
+	}
+	return expressions
+}
+
+function createFunctionBody(
+	mod: binaryen.Module,
+	expressions: binaryen.ExpressionRef[]
+): binaryen.ExpressionRef {
+	return expressions.length === 1
+		? (expressions[0] as binaryen.ExpressionRef)
+		: mod.block(null, expressions)
+}
+
+function setupStartFunction(mod: binaryen.Module, body: binaryen.ExpressionRef): void {
+	mod.addFunction('_start', binaryen.none, binaryen.none, [], body)
+	mod.addFunctionExport('_start', '_start')
+	const startFunc = mod.getFunction('_start')
+	if (startFunc !== undefined) {
+		mod.setStart(startFunc)
+	}
+}
+
+function emitResult(mod: binaryen.Module): CompileResult {
+	const valid = mod.validate() === 1
+	const binary = mod.emitBinary()
+	const text = mod.emitText()
+	mod.dispose()
+	return { binary, text, valid }
+}
+
+/**
+ * Compile a parsed TinyWhale program to WebAssembly.
+ *
+ * @param parseResult - The result of parsing a TinyWhale program
+ * @param options - Compilation options
+ * @returns The compilation result containing binary, text, and validation status
+ * @throws {CompileError} If the program is empty or contains unknown statement types
+ */
+export function compile(parseResult: ParseResult, options: CompileOptions = {}): CompileResult {
+	const mod = new binaryen.Module()
+	const expressions = collectExpressions(mod, parseResult)
+
+	if (expressions.length === 0) {
+		mod.dispose()
+		throw new CompileError('Empty program: at least one statement is required')
+	}
+
+	const body = createFunctionBody(mod, expressions)
+	setupStartFunction(mod, body)
+
+	if (options.optimize) {
+		mod.optimize()
+	}
+
+	return emitResult(mod)
+}

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -3,6 +3,12 @@ import * as ohm from 'ohm-js'
 export { ohm }
 
 export {
+	CompileError,
+	type CompileOptions,
+	type CompileResult,
+	compile,
+} from './codegen/index.ts'
+export {
 	createSemantics,
 	type IndentInfo,
 	type IndentToken,

--- a/packages/compiler/test/codegen.test.ts
+++ b/packages/compiler/test/codegen.test.ts
@@ -1,0 +1,158 @@
+import assert from 'node:assert'
+import { Readable } from 'node:stream'
+import { describe, it } from 'node:test'
+
+import { CompileError, type CompileResult, compile } from '../src/codegen/index.ts'
+import { parse } from '../src/grammar/index.ts'
+import { preprocess } from '../src/preprocessor/index.ts'
+
+/**
+ * Helper to compile a TinyWhale source string.
+ */
+async function compileSource(source: string, optimize = false): Promise<CompileResult> {
+	const preprocessed = await preprocess(Readable.from(source))
+	const parseResult = parse(preprocessed)
+	if (!parseResult.succeeded) {
+		throw new Error(`Parse failed: ${parseResult.message}`)
+	}
+	return compile(parseResult, { optimize })
+}
+
+describe('codegen', () => {
+	describe('compile function', () => {
+		it('should compile single panic statement to valid WASM', async () => {
+			const result = await compileSource('panic\n')
+
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.binary instanceof Uint8Array)
+			assert.ok(result.binary.length > 0)
+			assert.ok(result.text.includes('unreachable'))
+		})
+
+		it('should compile multiple panic statements', async () => {
+			const result = await compileSource('panic\npanic\n')
+
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('unreachable'))
+			// Count unreachable occurrences in the WAT output
+			const unreachableCount = (result.text.match(/unreachable/g) || []).length
+			assert.strictEqual(unreachableCount, 2)
+		})
+
+		it('should compile nested panic statements', async () => {
+			const result = await compileSource('panic\npanic\npanic\n')
+
+			assert.strictEqual(result.valid, true)
+			const unreachableCount = (result.text.match(/unreachable/g) || []).length
+			assert.strictEqual(unreachableCount, 3)
+		})
+
+		it('should throw CompileError for empty program', async () => {
+			const preprocessed = await preprocess(Readable.from('\n'))
+			const parseResult = parse(preprocessed)
+
+			assert.throws(
+				() => compile(parseResult),
+				(err: Error) => {
+					assert.ok(err instanceof CompileError)
+					assert.ok(err.message.includes('Empty program'))
+					return true
+				}
+			)
+		})
+
+		it('should throw CompileError for program with only comments', async () => {
+			const preprocessed = await preprocess(Readable.from('# just a comment\n'))
+			const parseResult = parse(preprocessed)
+
+			assert.throws(
+				() => compile(parseResult),
+				(err: Error) => {
+					assert.ok(err instanceof CompileError)
+					assert.ok(err.message.includes('Empty program'))
+					return true
+				}
+			)
+		})
+
+		it('should export _start function', async () => {
+			const result = await compileSource('panic\n')
+
+			assert.ok(result.text.includes('(export "_start"'))
+		})
+
+		it('should set _start as start function', async () => {
+			const result = await compileSource('panic\n')
+
+			assert.ok(result.text.includes('(start'))
+		})
+	})
+
+	describe('binary format', () => {
+		it('should produce valid WASM magic number', async () => {
+			const result = await compileSource('panic\n')
+
+			// WASM magic number: \0asm (0x00 0x61 0x73 0x6d)
+			assert.strictEqual(result.binary[0], 0x00)
+			assert.strictEqual(result.binary[1], 0x61)
+			assert.strictEqual(result.binary[2], 0x73)
+			assert.strictEqual(result.binary[3], 0x6d)
+		})
+
+		it('should produce valid WASM version', async () => {
+			const result = await compileSource('panic\n')
+
+			// WASM version 1: 0x01 0x00 0x00 0x00
+			assert.strictEqual(result.binary[4], 0x01)
+			assert.strictEqual(result.binary[5], 0x00)
+			assert.strictEqual(result.binary[6], 0x00)
+			assert.strictEqual(result.binary[7], 0x00)
+		})
+
+		it('should contain unreachable opcode (0x00)', async () => {
+			const result = await compileSource('panic\n')
+
+			// The unreachable instruction has opcode 0x00
+			// We need to search in the code section, but for simplicity
+			// we just verify the binary contains the opcode
+			assert.ok(result.binary.includes(0x00))
+		})
+	})
+
+	describe('optimization', () => {
+		it('should compile without optimization by default', async () => {
+			const result = await compileSource('panic\n')
+			assert.strictEqual(result.valid, true)
+		})
+
+		it('should compile with optimization when enabled', async () => {
+			const result = await compileSource('panic\n', true)
+			assert.strictEqual(result.valid, true)
+		})
+
+		it('should produce valid output with optimization', async () => {
+			const result = await compileSource('panic\npanic\n', true)
+
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.binary instanceof Uint8Array)
+			assert.ok(result.binary.length > 0)
+		})
+	})
+
+	describe('CompileError', () => {
+		it('should have correct name property', () => {
+			const error = new CompileError('test error')
+			assert.strictEqual(error.name, 'CompileError')
+		})
+
+		it('should have correct message property', () => {
+			const error = new CompileError('test error')
+			assert.strictEqual(error.message, 'test error')
+		})
+
+		it('should be instanceof Error', () => {
+			const error = new CompileError('test error')
+			assert.ok(error instanceof Error)
+		})
+	})
+})


### PR DESCRIPTION
- Add Binaryen-based codegen that compiles `panic` to `unreachable`
- Support root-level statements in grammar (RootLine rule)
- Refactor CLI build command with explicit --target (wasm|wat) flag
- Output path (-o) now specifies directory, filename derived from input
- Extract CLI utilities to separate module with unit tests
- Add 17 codegen tests and 25 CLI utility tests