### PR TITLE
refactor(parser): simplify indent token format (#16)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
 	"assist": {
 		"actions": {
 			"source": {
@@ -9,7 +9,13 @@
 		}
 	},
 	"files": {
-		"includes": ["**/*.ts", "**/*.json", "!dist", "!node_modules"]
+		"includes": [
+			"**/*.ts",
+			"**/*.json",
+			"!dist",
+			"!node_modules",
+			"!**/*.ohm-bundle.*"
+		]
 	},
 	"formatter": {
 		"enabled": true,
@@ -44,6 +50,21 @@
 			"recommended": true
 		}
 	},
+	"overrides": [
+		{
+			"includes": ["**/test/**", "**/*.test.ts"],
+			"linter": {
+				"rules": {
+					"complexity": {
+						"noExcessiveCognitiveComplexity": "off"
+					},
+					"style": {
+						"noNonNullAssertion": "off"
+					}
+				}
+			}
+		}
+	],
 	"vcs": {
 		"clientKind": "git",
 		"enabled": true,

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 # mise configuration for tinywhale monorepo
 [tools]
-node = "24.11.0"
-pnpm = "10.23.0"
+node = "24.12.0"
+pnpm = "10.26.0"
 
 [tasks.install]
 description = "Install dependencies"
@@ -9,11 +9,15 @@ run = "pnpm install"
 
 [tasks.update]
 description = "Update dependencies"
-run = "pnpm up --latest --workspace --interactive --recursive"
+run = "pnpm up --workspace --interactive --recursive --latest"
+
+[tasks.generate-grammar]
+description = "Generate Ohm grammar bundles with TypeScript types"
+run = "cd packages/compiler && npx @ohm-js/cli generateBundles --withTypes --esm 'src/parse/*.ohm'"
 
 [tasks.build]
 description = "Build all packages"
-# depends_post = ["lint", "test"]
+depends = ["generate-grammar"]
 run = "pnpm -r build"
 
 [tasks.test]
@@ -22,7 +26,7 @@ run = "pnpm -r test"
 
 [tasks.check]
 description = "Run biome check (lint & format)"
-run = "pnpm exec biome check --write"
+run = "pnpm exec biome check --write --max-diagnostics 100"
 
 [tasks.typecheck]
 description = "Run TypeScript type checking"

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
 	"author": "",
 	"description": "A programming language with compiler, CLI, and LSP server",
 	"devDependencies": {
-		"@biomejs/biome": "2.3.8",
-		"@types/node": "24.10.1",
+		"@biomejs/biome": "2.3.10",
+		"@types/node": "25.0.3",
 		"typescript": "5.9.3"
 	},
 	"engines": {
-		"node": "24.11.0",
-		"pnpm": "10.23.0"
+		"node": "24.12.0",
+		"pnpm": "10.26.0"
 	},
 	"keywords": [
 		"compiler",
@@ -17,7 +17,7 @@
 	],
 	"license": "MIT",
 	"name": "tinywhale",
-	"packageManager": "pnpm@10.23.0",
+	"packageManager": "pnpm@10.26.0",
 	"private": true,
 	"scripts": {
 		"start": "mise run"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
 	},
 	"description": "TinyWhale command-line interface",
 	"devDependencies": {
-		"@types/node": "24.10.1",
+		"@types/node": "25.0.3",
 		"typescript": "5.9.3"
 	},
 	"exports": {

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { args, BaseCommand, flags } from '@adonisjs/ace'
-import { compile, CompileError, type CompileResult } from '@tinywhale/compiler'
+import { type CompileResult, compile } from '@tinywhale/compiler'
 import {
 	formatCompileError,
 	formatReadError,

--- a/packages/compiler/.gitignore
+++ b/packages/compiler/.gitignore
@@ -1,5 +1,6 @@
 # Ignore every file
 *
+*/
 
 # Allow list for the current folder
 !.gitignore
@@ -9,8 +10,13 @@
 !docs/
 !docs/**
 !src/
-!src/**
+!src/**/
+!src/**/*.ts
+!src/**/*.ohm
 !test/
 !test/**
 !tsconfig.build.json
 !tsconfig.json
+
+# Re-ignore declaration files
+src/**/*.d.ts

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -2,11 +2,12 @@
 	"author": "",
 	"dependencies": {
 		"binaryen": "125.0.0",
-		"ohm-js": "17.2.1"
+		"ohm-js": "17.3.0"
 	},
 	"description": "TinyWhale compiler library",
 	"devDependencies": {
-		"@types/node": "24.10.1",
+		"@ohm-js/cli": "2.0.1",
+		"@types/node": "25.0.3",
 		"typescript": "5.9.3"
 	},
 	"exports": {
@@ -27,7 +28,7 @@
 	"name": "@tinywhale/compiler",
 	"scripts": {
 		"build": "tsc -p tsconfig.build.json",
-		"clean": "rm -rf dist",
+		"clean": "rm -rf dist src/parse/*.ohm-bundle.*",
 		"test": "node --test test/*.test.ts test/core/*.test.ts test/lex/*.test.ts test/parse/*.test.ts"
 	},
 	"type": "module",

--- a/packages/compiler/src/codegen/index.ts
+++ b/packages/compiler/src/codegen/index.ts
@@ -1,7 +1,7 @@
 import binaryen from 'binaryen'
 
 import type { CompilationContext } from '../core/context.ts'
-import { NodeKind, type NodeId } from '../core/nodes.ts'
+import { type NodeId, NodeKind } from '../core/nodes.ts'
 
 /**
  * Error thrown when compilation fails.

--- a/packages/compiler/src/core/context.ts
+++ b/packages/compiler/src/core/context.ts
@@ -187,7 +187,7 @@ export class CompilationContext {
 		}
 
 		// Build pointer line
-		const pointer = ' '.repeat(diagnostic.column - 1) + '^'
+		const pointer = `${' '.repeat(diagnostic.column - 1)}^`
 
 		return `${header}\n  ${sourceLine}\n  ${pointer}`
 	}

--- a/packages/compiler/src/core/nodes.ts
+++ b/packages/compiler/src/core/nodes.ts
@@ -144,7 +144,8 @@ export class NodeStore {
 
 		while (pos >= (start as number)) {
 			const childId = pos as NodeId
-			const child = this.nodes[childId]!
+			const child = this.nodes[childId]
+			if (child === undefined) break
 			yield [childId, child]
 			// Move backwards past this child's subtree to find previous sibling
 			pos -= child.subtreeSize
@@ -159,7 +160,8 @@ export class NodeStore {
 		const node = this.get(id)
 		const start = id - node.subtreeSize + 1
 		for (let i = start; i <= id; i++) {
-			yield [i as NodeId, this.nodes[i]!]
+			const n = this.nodes[i]
+			if (n !== undefined) yield [i as NodeId, n]
 		}
 	}
 
@@ -169,7 +171,8 @@ export class NodeStore {
 	 */
 	*[Symbol.iterator](): Generator<[NodeId, ParseNode]> {
 		for (let i = 0; i < this.nodes.length; i++) {
-			yield [i as NodeId, this.nodes[i]!]
+			const node = this.nodes[i]
+			if (node !== undefined) yield [i as NodeId, node]
 		}
 	}
 }

--- a/packages/compiler/src/core/tokens.ts
+++ b/packages/compiler/src/core/tokens.ts
@@ -103,7 +103,8 @@ export class TokenStore {
 	 */
 	*[Symbol.iterator](): Generator<[TokenId, Token]> {
 		for (let i = 0; i < this.tokens.length; i++) {
-			yield [i as TokenId, this.tokens[i]!]
+			const token = this.tokens[i]
+			if (token !== undefined) yield [i as TokenId, token]
 		}
 	}
 

--- a/packages/compiler/src/parse/index.ts
+++ b/packages/compiler/src/parse/index.ts
@@ -3,4 +3,4 @@
  * Parses tokens into a flat node array using Ohm.js.
  */
 
-export { matchOnly, parse, type ParseResult } from './parser.ts'
+export { matchOnly, type ParseResult, parse } from './parser.ts'

--- a/packages/compiler/src/parse/tinywhale.ohm
+++ b/packages/compiler/src/parse/tinywhale.ohm
@@ -1,0 +1,25 @@
+TinyWhale {
+  Program (a program) = Line*
+  Line (a line) = IndentedLine | DedentLine | RootLine
+
+  IndentedLine = indentToken Statement?
+  DedentLine = dedentToken+ Statement?
+  RootLine = Statement
+
+  // Statements
+  Statement = PanicStatement
+  PanicStatement = panic
+
+  // Keywords
+  keyword = panic
+  panic = "panic" ~identifierPart
+  identifierPart = alnum | "_"
+
+  // Lexical token rules (marker followed by indent level)
+  indentToken = "⇥" digit+
+  dedentToken = "⇤" digit+
+
+  // Comments treated as whitespace
+  space += comment
+  comment = "#" (~("#" | "\n" | "\r" | dedentToken) any)* ("#" | &"\n" | &"\r" | &dedentToken | end)
+}

--- a/packages/compiler/test/compile.test.ts
+++ b/packages/compiler/test/compile.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
-import { compile, CompileError } from '../src/index.ts'
+import { CompileError, compile } from '../src/index.ts'
 
 describe('compile (unified API)', () => {
 	describe('basic compilation', () => {

--- a/packages/compiler/test/core/context.test.ts
+++ b/packages/compiler/test/core/context.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
-import { CompilationContext, type Diagnostic, DiagnosticSeverity } from '../../src/core/context.ts'
+import { CompilationContext, DiagnosticSeverity } from '../../src/core/context.ts'
 import { NodeKind } from '../../src/core/nodes.ts'
 import { TokenKind } from '../../src/core/tokens.ts'
 

--- a/packages/compiler/test/core/nodes.test.ts
+++ b/packages/compiler/test/core/nodes.test.ts
@@ -177,10 +177,10 @@ describe('core/nodes', () => {
 
 			// Should get both RootLine nodes (indices 3 and 1, in reverse order)
 			assert.strictEqual(children.length, 2)
-			assert.strictEqual(children[0]![0], 3) // line2 first (reverse order)
-			assert.strictEqual(children[0]![1].kind, NodeKind.RootLine)
-			assert.strictEqual(children[1]![0], 1) // line1 second
-			assert.strictEqual(children[1]![1].kind, NodeKind.RootLine)
+			assert.strictEqual(children[0]?.[0], 3) // line2 first (reverse order)
+			assert.strictEqual(children[0]?.[1].kind, NodeKind.RootLine)
+			assert.strictEqual(children[1]?.[0], 1) // line1 second
+			assert.strictEqual(children[1]?.[1].kind, NodeKind.RootLine)
 		})
 
 		it('should iterate subtree correctly', () => {

--- a/packages/compiler/test/core/tokens.test.ts
+++ b/packages/compiler/test/core/tokens.test.ts
@@ -86,12 +86,12 @@ describe('core/tokens', () => {
 			}
 
 			assert.strictEqual(collected.length, 3)
-			assert.strictEqual(collected[0]![0], 0)
-			assert.strictEqual(collected[0]![1].kind, TokenKind.Indent)
-			assert.strictEqual(collected[1]![0], 1)
-			assert.strictEqual(collected[1]![1].kind, TokenKind.Panic)
-			assert.strictEqual(collected[2]![0], 2)
-			assert.strictEqual(collected[2]![1].kind, TokenKind.Dedent)
+			assert.strictEqual(collected[0]?.[0], 0)
+			assert.strictEqual(collected[0]?.[1].kind, TokenKind.Indent)
+			assert.strictEqual(collected[1]?.[0], 1)
+			assert.strictEqual(collected[1]?.[1].kind, TokenKind.Panic)
+			assert.strictEqual(collected[2]?.[0], 2)
+			assert.strictEqual(collected[2]?.[1].kind, TokenKind.Dedent)
 		})
 
 		it('should slice tokens by range', () => {
@@ -104,8 +104,8 @@ describe('core/tokens', () => {
 			const slice = store.slice(tokenId(1), tokenId(3))
 
 			assert.strictEqual(slice.length, 2)
-			assert.strictEqual(slice[0]!.kind, TokenKind.Panic)
-			assert.strictEqual(slice[1]!.kind, TokenKind.Dedent)
+			assert.strictEqual(slice[0]?.kind, TokenKind.Panic)
+			assert.strictEqual(slice[1]?.kind, TokenKind.Dedent)
 		})
 	})
 })

--- a/packages/compiler/test/parse/parser.test.ts
+++ b/packages/compiler/test/parse/parser.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { CompilationContext } from '../../src/core/context.ts'
-import { NodeKind, type NodeId } from '../../src/core/nodes.ts'
+import { type NodeId, NodeKind } from '../../src/core/nodes.ts'
 import { tokenize } from '../../src/lex/tokenizer.ts'
 import { parse } from '../../src/parse/parser.ts'
 
@@ -19,7 +19,7 @@ describe('parse/parser', () => {
 	describe('basic parsing', () => {
 		it('should parse empty input', () => {
 			const ctx = tokenizeAndParse('')
-			const result = parse(ctx)
+			parse(ctx)
 
 			// Note: we called parse twice, but that's ok for this test
 			assert.strictEqual(ctx.hasErrors(), false)
@@ -42,7 +42,8 @@ describe('parse/parser', () => {
 			tokenize(ctx)
 			const result = parse(ctx)
 
-			const rootNode = ctx.nodes.get(result.rootNode!)
+			assert.ok(result.rootNode !== undefined, 'rootNode should be defined')
+			const rootNode = ctx.nodes.get(result.rootNode)
 			assert.strictEqual(rootNode.kind, NodeKind.Program)
 		})
 
@@ -160,7 +161,8 @@ describe('parse/parser', () => {
 			// 2 panics + 2 rootlines + 1 program = 5 nodes
 			assert.strictEqual(ctx.nodes.count(), 5)
 
-			const programNode = ctx.nodes.get(result.rootNode!)
+			assert.ok(result.rootNode !== undefined, 'rootNode should be defined')
+			const programNode = ctx.nodes.get(result.rootNode)
 			assert.strictEqual(programNode.subtreeSize, 5)
 		})
 	})
@@ -180,8 +182,9 @@ describe('parse/parser', () => {
 			tokenize(ctx)
 			const result = parse(ctx)
 
+			assert.ok(result.rootNode !== undefined, 'rootNode should be defined')
 			const children: number[] = []
-			for (const [id, node] of ctx.nodes.iterateChildren(result.rootNode!)) {
+			for (const [_id, node] of ctx.nodes.iterateChildren(result.rootNode)) {
 				children.push(node.kind)
 			}
 

--- a/packages/compiler/tsconfig.build.json
+++ b/packages/compiler/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
 		"allowImportingTsExtensions": true,
+		"allowJs": true,
 		"declaration": true,
 		"declarationMap": true,
 		"noEmit": false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.3.8
-        version: 2.3.8
+        specifier: 2.3.10
+        version: 2.3.10
       '@types/node':
-        specifier: 24.10.1
-        version: 24.10.1
+        specifier: 25.0.3
+        version: 25.0.3
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -28,8 +28,8 @@ importers:
         version: link:../compiler
     devDependencies:
       '@types/node':
-        specifier: 24.10.1
-        version: 24.10.1
+        specifier: 25.0.3
+        version: 25.0.3
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -40,12 +40,15 @@ importers:
         specifier: 125.0.0
         version: 125.0.0
       ohm-js:
-        specifier: 17.2.1
-        version: 17.2.1
+        specifier: 17.3.0
+        version: 17.3.0
     devDependencies:
+      '@ohm-js/cli':
+        specifier: 2.0.1
+        version: 2.0.1(ohm-js@17.3.0)
       '@types/node':
-        specifier: 24.10.1
-        version: 24.10.1
+        specifier: 25.0.3
+        version: 25.0.3
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -62,55 +65,55 @@ packages:
     resolution: {integrity: sha512-7Wq6CpXmQm3m/6fKfzubAadCdiH2kKSni+K8s5KcTIFryKSqW+f06UAPOUwRJWqy80hnVlujAjveIsNJSPeJjA==}
     engines: {node: '>=18.16.0'}
 
-  '@biomejs/biome@2.3.8':
-    resolution: {integrity: sha512-Qjsgoe6FEBxWAUzwFGFrB+1+M8y/y5kwmg5CHac+GSVOdmOIqsAiXM5QMVGZJ1eCUCLlPZtq4aFAQ0eawEUuUA==}
+  '@biomejs/biome@2.3.10':
+    resolution: {integrity: sha512-/uWSUd1MHX2fjqNLHNL6zLYWBbrJeG412/8H7ESuK8ewoRoMPUgHDebqKrPTx/5n6f17Xzqc9hdg3MEqA5hXnQ==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.3.8':
-    resolution: {integrity: sha512-HM4Zg9CGQ3txTPflxD19n8MFPrmUAjaC7PQdLkugeeC0cQ+PiVrd7i09gaBS/11QKsTDBJhVg85CEIK9f50Qww==}
+  '@biomejs/cli-darwin-arm64@2.3.10':
+    resolution: {integrity: sha512-M6xUjtCVnNGFfK7HMNKa593nb7fwNm43fq1Mt71kpLpb+4mE7odO8W/oWVDyBVO4ackhresy1ZYO7OJcVo/B7w==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.3.8':
-    resolution: {integrity: sha512-lUDQ03D7y/qEao7RgdjWVGCu+BLYadhKTm40HkpJIi6kn8LSv5PAwRlew/DmwP4YZ9ke9XXoTIQDO1vAnbRZlA==}
+  '@biomejs/cli-darwin-x64@2.3.10':
+    resolution: {integrity: sha512-Vae7+V6t/Avr8tVbFNjnFSTKZogZHFYl7MMH62P/J1kZtr0tyRQ9Fe0onjqjS2Ek9lmNLmZc/VR5uSekh+p1fg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.3.8':
-    resolution: {integrity: sha512-PShR4mM0sjksUMyxbyPNMxoKFPVF48fU8Qe8Sfx6w6F42verbwRLbz+QiKNiDPRJwUoMG1nPM50OBL3aOnTevA==}
+  '@biomejs/cli-linux-arm64-musl@2.3.10':
+    resolution: {integrity: sha512-B9DszIHkuKtOH2IFeeVkQmSMVUjss9KtHaNXquYYWCjH8IstNgXgx5B0aSBQNr6mn4RcKKRQZXn9Zu1rM3O0/A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@2.3.8':
-    resolution: {integrity: sha512-Uo1OJnIkJgSgF+USx970fsM/drtPcQ39I+JO+Fjsaa9ZdCN1oysQmy6oAGbyESlouz+rzEckLTF6DS7cWse95g==}
+  '@biomejs/cli-linux-arm64@2.3.10':
+    resolution: {integrity: sha512-hhPw2V3/EpHKsileVOFynuWiKRgFEV48cLe0eA+G2wO4SzlwEhLEB9LhlSrVeu2mtSn205W283LkX7Fh48CaxA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@2.3.8':
-    resolution: {integrity: sha512-YGLkqU91r1276uwSjiUD/xaVikdxgV1QpsicT0bIA1TaieM6E5ibMZeSyjQ/izBn4tKQthUSsVZacmoJfa3pDA==}
+  '@biomejs/cli-linux-x64-musl@2.3.10':
+    resolution: {integrity: sha512-QTfHZQh62SDFdYc2nfmZFuTm5yYb4eO1zwfB+90YxUumRCR171tS1GoTX5OD0wrv4UsziMPmrePMtkTnNyYG3g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@2.3.8':
-    resolution: {integrity: sha512-QDPMD5bQz6qOVb3kiBui0zKZXASLo0NIQ9JVJio5RveBEFgDgsvJFUvZIbMbUZT3T00M/1wdzwWXk4GIh0KaAw==}
+  '@biomejs/cli-linux-x64@2.3.10':
+    resolution: {integrity: sha512-wwAkWD1MR95u+J4LkWP74/vGz+tRrIQvr8kfMMJY8KOQ8+HMVleREOcPYsQX82S7uueco60L58Wc6M1I9WA9Dw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@2.3.8':
-    resolution: {integrity: sha512-H4IoCHvL1fXKDrTALeTKMiE7GGWFAraDwBYFquE/L/5r1927Te0mYIGseXi4F+lrrwhSWbSGt5qPFswNoBaCxg==}
+  '@biomejs/cli-win32-arm64@2.3.10':
+    resolution: {integrity: sha512-o7lYc9n+CfRbHvkjPhm8s9FgbKdYZu5HCcGVMItLjz93EhgJ8AM44W+QckDqLA9MKDNFrR8nPbO4b73VC5kGGQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.3.8':
-    resolution: {integrity: sha512-RguzimPoZWtBapfKhKjcWXBVI91tiSprqdBYu7tWhgN8pKRZhw24rFeNZTNf6UiBfjCYCi9eFQs/JzJZIhuK4w==}
+  '@biomejs/cli-win32-x64@2.3.10':
+    resolution: {integrity: sha512-pHEFgq7dUEsKnqG9mx9bXihxGI49X+ar+UBrEIj3Wqj3UCZp1rNgV+OoyjFgcXsjCWpuEAF4VJdkZr3TrWdCbQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -122,6 +125,24 @@ packages:
   '@lukeed/ms@2.0.2':
     resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
     engines: {node: '>=8'}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@ohm-js/cli@2.0.1':
+    resolution: {integrity: sha512-LKU5hGd/vmgsoZaWA9cEn7R84jRYg/2nUmHnozVGq0zIM++n9JPXvHBSJM8MHJIKm+RSDd19oKTbNs8nmio1nw==}
+    hasBin: true
+    peerDependencies:
+      ohm-js: ^17.0.0
 
   '@poppinss/cliui@6.5.0':
     resolution: {integrity: sha512-Z1eJxk0k/JZvTjeL8RZ/K8SFfB7RIajoAzBFeOFBzJ8zM0sm9u7gWZS/q+8GChozcV20WdJNwSPrbq/BToJl0w==}
@@ -155,8 +176,8 @@ packages:
   '@types/bytes@3.1.5':
     resolution: {integrity: sha512-VgZkrJckypj85YxEsEavcMmmSOIzkUHqWmM4CCyia5dc54YwsXzJ5uT4fYxBQNEXx+oF1krlhgCbvfubXqZYsQ==}
 
-  '@types/node@24.10.1':
-    resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
+  '@types/node@25.0.3':
+    resolution: {integrity: sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==}
 
   '@types/pluralize@0.0.33':
     resolution: {integrity: sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==}
@@ -188,6 +209,10 @@ packages:
     resolution: {integrity: sha512-X7CUM9ZnwL/Ow++JH5AJKiemc82J7JyeryuPvXQdXBLcL/rqrC5KMUB1mHiORSolietH9sotvaOZlr6HSwPAlw==}
     hasBin: true
 
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -212,6 +237,10 @@ packages:
     resolution: {integrity: sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==}
     engines: {node: '>=20'}
 
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
@@ -233,9 +262,20 @@ packages:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
+
+  fastq@1.19.1:
+    resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
 
   flattie@1.1.1:
     resolution: {integrity: sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==}
@@ -248,6 +288,14 @@ packages:
   get-source@2.0.12:
     resolution: {integrity: sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==}
 
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -255,6 +303,14 @@ packages:
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
     engines: {node: '>=18'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
 
   jsonschema@1.5.0:
     resolution: {integrity: sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==}
@@ -267,6 +323,14 @@ packages:
     resolution: {integrity: sha512-cSSF1K5w9juI2+JeSRAdaTUZJf6cJB0aWwWO1nQQkcWw44+bIfXmhZMwK2eEsv6tXvU3UfKX/kzcX6SP+1tLAw==}
     engines: {node: '>=20'}
 
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
@@ -275,13 +339,17 @@ packages:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
     hasBin: true
 
-  ohm-js@17.2.1:
-    resolution: {integrity: sha512-4cXF0G09fAYU9z61kTfkNbKK1Kz/sGEZ5NbVWHoe9Qi7VB7y+Spwk051CpUTfUENdlIr+vt8tMV4/LosTE2cDQ==}
+  ohm-js@17.3.0:
+    resolution: {integrity: sha512-LySMdjweN1hKBMMV8lM44+1wiewkndDNNJxtgVAscs7y683MXCdQZLsIaw64/p8NuqYbKOWZoHIOA5DU/xchoA==}
     engines: {node: '>=0.12.1'}
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
+
+  picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -294,9 +362,19 @@ packages:
   printable-characters@1.0.42:
     resolution: {integrity: sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==}
 
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
@@ -352,6 +430,10 @@ packages:
     resolution: {integrity: sha512-rcdty1xZ2/BkWa4ANjWRp4JGpda2quksXIHgn5TMjNBPZfwzJIgR68DKfSYiTL+CZWowDX/sbOo5ME/FRURvYQ==}
     engines: {node: '>=18'}
 
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
   truncatise@0.0.8:
     resolution: {integrity: sha512-cXzueh9pzBCsLzhToB4X4gZCb3KYkrsAcBAX97JnazE74HOl3cpBJYEV7nabHeG/6/WXCU5Yujlde/WPBUwnsg==}
 
@@ -396,45 +478,63 @@ snapshots:
       youch: 3.3.4
       youch-terminal: 2.2.3
 
-  '@biomejs/biome@2.3.8':
+  '@biomejs/biome@2.3.10':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.3.8
-      '@biomejs/cli-darwin-x64': 2.3.8
-      '@biomejs/cli-linux-arm64': 2.3.8
-      '@biomejs/cli-linux-arm64-musl': 2.3.8
-      '@biomejs/cli-linux-x64': 2.3.8
-      '@biomejs/cli-linux-x64-musl': 2.3.8
-      '@biomejs/cli-win32-arm64': 2.3.8
-      '@biomejs/cli-win32-x64': 2.3.8
+      '@biomejs/cli-darwin-arm64': 2.3.10
+      '@biomejs/cli-darwin-x64': 2.3.10
+      '@biomejs/cli-linux-arm64': 2.3.10
+      '@biomejs/cli-linux-arm64-musl': 2.3.10
+      '@biomejs/cli-linux-x64': 2.3.10
+      '@biomejs/cli-linux-x64-musl': 2.3.10
+      '@biomejs/cli-win32-arm64': 2.3.10
+      '@biomejs/cli-win32-x64': 2.3.10
 
-  '@biomejs/cli-darwin-arm64@2.3.8':
+  '@biomejs/cli-darwin-arm64@2.3.10':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.3.8':
+  '@biomejs/cli-darwin-x64@2.3.10':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.3.8':
+  '@biomejs/cli-linux-arm64-musl@2.3.10':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.3.8':
+  '@biomejs/cli-linux-arm64@2.3.10':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.3.8':
+  '@biomejs/cli-linux-x64-musl@2.3.10':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.3.8':
+  '@biomejs/cli-linux-x64@2.3.10':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.3.8':
+  '@biomejs/cli-win32-arm64@2.3.10':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.3.8':
+  '@biomejs/cli-win32-x64@2.3.10':
     optional: true
 
   '@colors/colors@1.5.0':
     optional: true
 
   '@lukeed/ms@2.0.2': {}
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.19.1
+
+  '@ohm-js/cli@2.0.1(ohm-js@17.3.0)':
+    dependencies:
+      commander: 8.3.0
+      fast-glob: 3.3.3
+      ohm-js: 17.3.0
 
   '@poppinss/cliui@6.5.0':
     dependencies:
@@ -490,7 +590,7 @@ snapshots:
 
   '@types/bytes@3.1.5': {}
 
-  '@types/node@24.10.1':
+  '@types/node@25.0.3':
     dependencies:
       undici-types: 7.16.0
 
@@ -514,6 +614,10 @@ snapshots:
 
   binaryen@125.0.0: {}
 
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
   bytes@3.1.2: {}
 
   case-anything@3.1.2: {}
@@ -535,6 +639,8 @@ snapshots:
       slice-ansi: 7.1.2
       string-width: 8.1.0
 
+  commander@8.3.0: {}
+
   cookie@0.7.2: {}
 
   data-uri-to-buffer@2.0.2: {}
@@ -550,7 +656,23 @@ snapshots:
 
   environment@1.1.0: {}
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fastest-levenshtein@1.0.16: {}
+
+  fastq@1.19.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
 
   flattie@1.1.1: {}
 
@@ -561,11 +683,23 @@ snapshots:
       data-uri-to-buffer: 2.0.2
       source-map: 0.6.1
 
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  is-extglob@2.1.1: {}
+
   is-fullwidth-code-point@3.0.0: {}
 
   is-fullwidth-code-point@5.1.0:
     dependencies:
       get-east-asian-width: 1.4.0
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
 
   jsonschema@1.5.0: {}
 
@@ -579,15 +713,24 @@ snapshots:
       strip-ansi: 7.1.2
       wrap-ansi: 9.0.2
 
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.1
+
   mimic-function@5.0.1: {}
 
   mustache@4.2.0: {}
 
-  ohm-js@17.2.1: {}
+  ohm-js@17.3.0: {}
 
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  picomatch@2.3.1: {}
 
   pluralize@8.0.0: {}
 
@@ -595,10 +738,18 @@ snapshots:
 
   printable-characters@1.0.42: {}
 
+  queue-microtask@1.2.3: {}
+
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
+
+  reusify@1.1.0: {}
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
 
   safe-stable-stringify@2.5.0: {}
 
@@ -648,6 +799,10 @@ snapshots:
   supports-color@10.2.2: {}
 
   terminal-size@4.0.0: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
 
   truncatise@0.0.8: {}
 


### PR DESCRIPTION
  - Re-extract Ohm grammar to standalone tinywhale.ohm file
  - Generate typed bundles via @ohm-js/cli for type safety
  - Simplify indent token format from ⟨line,level⟩⇥ to ⇥level
  - Refactor tokenizer functions to reduce cognitive complexity
  - Add biome overrides for test file complexity rules

  The line number in indent tokens was redundant because:
  1. tokensToOhmInput already inserts \n based on token.line
  2. Ohm preserves newlines in node.source
  3. getLineNumber(this) derives line by counting newlines