### PR TITLE
feat(compiler): add variable bindings with type checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ This is a monorepo managed with [pnpm](https://pnpm.io/) workspaces:
 
 - **`packages/compiler`** - The TinyWhale compiler library
 - **`packages/cli`** - Command-line interface for TinyWhale
+- **`packages/diagnostics`** - Shared diagnostic types and definitions
 - **`packages/lsp`** - Language Server Protocol implementation
 
 ## Prerequisites
 
 - [mise](https://mise.jdx.dev/) - Development tool version manager and task runner
-- Node.js 24.11.0 (automatically installed via mise)
-- pnpm 10.23.0 (automatically installed via mise)
+- Node.js 24.12.0 (automatically installed via mise)
+- pnpm 10.26.0 (automatically installed via mise)
 
 ## Getting Started
 
@@ -31,20 +32,20 @@ This is a monorepo managed with [pnpm](https://pnpm.io/) workspaces:
 
 ## Available Tasks
 
-All tasks are defined in `.mise.toml` and run via mise:
+All tasks are defined in `mise.toml` and run via mise:
 
 - `mise run install` - Install dependencies
 - `mise run build` - Build all packages
-- `mise run test` - Run tests for all packages
-- `mise run lint` - Lint all packages
+- `mise run test` - Run tests
+- `mise run check` - Lint and format (Biome, with auto-fix)
+- `mise run typecheck` - TypeScript type checking
 - `mise run clean` - Clean build artifacts
-- `mise run dev` - Run development mode
-
-You can also use `pnpm start <task>` which will execute `mise run <task>`.
+- `mise run generate-grammar` - Regenerate Ohm grammar bundles
+- `mise run cli <file>` - Run the TinyWhale CLI
 
 ## Development
 
-The project uses mise as the task runner. All tasks are defined in `.mise.toml`, and the root `package.json` contains only one script that delegates to mise.
+The project uses mise as the task runner. All tasks are defined in `mise.toml`.
 
 ## License
 

--- a/examples/bindings.tw
+++ b/examples/bindings.tw
@@ -1,0 +1,4 @@
+# Variable bindings with type annotations
+x:i32 = 42
+y:i64 = 100
+panic

--- a/examples/errors/type-mismatch.tw
+++ b/examples/errors/type-mismatch.tw
@@ -1,0 +1,4 @@
+# Error: type mismatch between i64 and i32
+x:i64 = 100
+y:i32 = x
+panic

--- a/examples/errors/undefined-variable.tw
+++ b/examples/errors/undefined-variable.tw
@@ -1,0 +1,3 @@
+# Error: referencing undefined variable
+x:i32 = y
+panic

--- a/examples/references.tw
+++ b/examples/references.tw
@@ -1,0 +1,5 @@
+# Variables can reference previously defined variables
+a:i32 = 10
+b:i32 = a      # b gets value of a
+c:i32 = b      # c gets value of b
+panic

--- a/examples/shadowing.tw
+++ b/examples/shadowing.tw
@@ -1,0 +1,5 @@
+# Variable shadowing - each binding creates a fresh local
+x:i32 = 1
+x:i32 = 2      # shadows previous x
+y:i32 = x      # y gets value 2
+panic

--- a/packages/compiler/src/check/checker.ts
+++ b/packages/compiler/src/check/checker.ts
@@ -224,7 +224,8 @@ function checkExpression(
 		case NodeKind.Identifier:
 			return checkVarRef(exprId, expectedType, state, context)
 		default:
-			// Unknown expression kind
+			// Should be unreachable - all expression kinds should be handled
+			console.assert(false, 'checkExpression: unhandled expression kind %d', node.kind)
 			return { instId: -1 as InstId, typeId: BuiltinTypeId.Invalid }
 	}
 }

--- a/packages/compiler/src/check/index.ts
+++ b/packages/compiler/src/check/index.ts
@@ -6,7 +6,7 @@
  */
 
 export { check } from './checker.ts'
-export { InstStore, ScopeStore } from './stores.ts'
+export { InstStore, ScopeStore, TypeStore } from './stores.ts'
 export {
 	BuiltinTypeId,
 	type CheckResult,
@@ -18,5 +18,7 @@ export {
 	type ScopeId,
 	scopeId,
 	type TypeId,
+	type TypeInfo,
+	TypeKind,
 	typeId,
 } from './types.ts'

--- a/packages/compiler/src/check/stores.ts
+++ b/packages/compiler/src/check/stores.ts
@@ -3,7 +3,24 @@
  * Carbon-style data-oriented design.
  */
 
-import { type Inst, type InstId, instId, type Scope, type ScopeId, scopeId } from './types.ts'
+import type { StringId } from '../core/context.ts'
+import type { NodeId } from '../core/nodes.ts'
+import {
+	BuiltinTypeId,
+	type Inst,
+	type InstId,
+	instId,
+	type Scope,
+	type ScopeId,
+	type SymbolEntry,
+	type SymbolId,
+	scopeId,
+	symbolId,
+	type TypeId,
+	type TypeInfo,
+	TypeKind,
+	typeId,
+} from './types.ts'
 
 /**
  * Dense array storage for semantic instructions.
@@ -80,6 +97,215 @@ export class ScopeStore {
 		for (let i = 0; i < this.scopes.length; i++) {
 			const scope = this.scopes[i]
 			if (scope !== undefined) yield [scopeId(i), scope]
+		}
+	}
+}
+
+/**
+ * Dense array storage for symbols (variable bindings).
+ * Supports shadowing: same name can be bound multiple times,
+ * each with a fresh local index.
+ */
+export class SymbolStore {
+	private readonly symbols: SymbolEntry[] = []
+	/** Current binding per name (overwrites on shadowing) */
+	private readonly nameToSymbol: Map<number, SymbolId> = new Map()
+	/** Next WASM local index to allocate */
+	private nextLocalIndex = 0
+
+	/**
+	 * Add a new symbol binding.
+	 * Allocates a fresh local index and overwrites any previous binding of the same name.
+	 */
+	add(entry: Omit<SymbolEntry, 'localIndex'>): SymbolId {
+		const localIndex = this.nextLocalIndex++
+		const id = symbolId(this.symbols.length)
+		const fullEntry: SymbolEntry = { ...entry, localIndex }
+		this.symbols.push(fullEntry)
+		// Overwrite previous binding (shadowing)
+		this.nameToSymbol.set(entry.nameId as number, id)
+		return id
+	}
+
+	/**
+	 * Look up the current binding for a name.
+	 * Returns undefined if the name has not been bound.
+	 */
+	lookupByName(nameId: StringId): SymbolId | undefined {
+		return this.nameToSymbol.get(nameId as number)
+	}
+
+	/**
+	 * Get symbol entry by ID.
+	 */
+	get(id: SymbolId): SymbolEntry {
+		const entry = this.symbols[id]
+		if (entry === undefined) {
+			throw new Error(`Invalid SymbolId: ${id}`)
+		}
+		return entry
+	}
+
+	/**
+	 * Get total number of symbols (= number of WASM locals needed).
+	 */
+	count(): number {
+		return this.symbols.length
+	}
+
+	/**
+	 * Get the number of WASM locals needed.
+	 */
+	localCount(): number {
+		return this.nextLocalIndex
+	}
+
+	*[Symbol.iterator](): Generator<[SymbolId, SymbolEntry]> {
+		for (let i = 0; i < this.symbols.length; i++) {
+			const entry = this.symbols[i]
+			if (entry !== undefined) yield [symbolId(i), entry]
+		}
+	}
+}
+
+/**
+ * Dense array storage for types.
+ * Bootstrapped with primitive types at indices 0-4.
+ * Append-only during the check phase.
+ *
+ * TinyWhale uses nominal types:
+ * - Primitives (i32, i64, f32, f64) are first-class structural types
+ * - All `type X = T` declarations create distinct (incompatible) types
+ * - Type checking is O(1) via integer comparison
+ */
+export class TypeStore {
+	private readonly types: TypeInfo[] = []
+	private readonly nameToId: Map<string, TypeId> = new Map()
+
+	constructor() {
+		this.bootstrapBuiltins()
+	}
+
+	/**
+	 * Initialize builtin types at fixed indices.
+	 */
+	private bootstrapBuiltins(): void {
+		// Must be added in exact order to match BuiltinTypeId indices
+		this.addBuiltin(TypeKind.None, 'none') // 0
+		this.addBuiltin(TypeKind.I32, 'i32') // 1
+		this.addBuiltin(TypeKind.I64, 'i64') // 2
+		this.addBuiltin(TypeKind.F32, 'f32') // 3
+		this.addBuiltin(TypeKind.F64, 'f64') // 4
+	}
+
+	private addBuiltin(kind: TypeKind, name: string): void {
+		const id = typeId(this.types.length)
+		const info: TypeInfo = {
+			kind,
+			name,
+			parseNodeId: null,
+			underlying: id, // Builtins reference themselves
+		}
+		this.types.push(info)
+		this.nameToId.set(name, id)
+	}
+
+	/**
+	 * Declare a distinct (nominal) type.
+	 * Every call returns a FRESH TypeId, different from the underlying.
+	 *
+	 * Example: `type UserId = i32` creates a distinct type where:
+	 * - TypeId is fresh (e.g., 5)
+	 * - underlying is i32's TypeId (1)
+	 * - UserId ≠ i32 at compile time
+	 * - At WASM level, UserId is just i32
+	 */
+	declareDistinct(name: string, underlying: TypeId, parseNodeId: NodeId): TypeId {
+		const id = typeId(this.types.length)
+		const info: TypeInfo = {
+			kind: TypeKind.Distinct,
+			name,
+			parseNodeId,
+			underlying,
+		}
+		this.types.push(info)
+		this.nameToId.set(name, id)
+		return id
+	}
+
+	/**
+	 * Look up a type by name.
+	 * Returns undefined if not found.
+	 */
+	lookup(name: string): TypeId | undefined {
+		return this.nameToId.get(name)
+	}
+
+	/**
+	 * Get type info by ID.
+	 * Throws if ID is invalid.
+	 */
+	get(id: TypeId): TypeInfo {
+		if (id === BuiltinTypeId.Invalid) {
+			throw new Error('Cannot get TypeInfo for Invalid sentinel')
+		}
+		const info = this.types[id]
+		if (info === undefined) {
+			throw new Error(`Invalid TypeId: ${id}`)
+		}
+		return info
+	}
+
+	/**
+	 * Check if two types are equal.
+	 * O(1) integer comparison - the core of nominal typing.
+	 */
+	areEqual(a: TypeId, b: TypeId): boolean {
+		return a === b
+	}
+
+	/**
+	 * Get human-readable type name for diagnostics.
+	 */
+	typeName(id: TypeId): string {
+		if (id === BuiltinTypeId.Invalid) {
+			return '<invalid>'
+		}
+		const info = this.types[id]
+		return info?.name ?? `<unknown type ${id}>`
+	}
+
+	/**
+	 * Unwrap distinct types to get the underlying WASM primitive.
+	 * Used for code generation where UserId becomes i32.
+	 */
+	toWasmType(id: TypeId): TypeId {
+		if (id === BuiltinTypeId.Invalid) {
+			return BuiltinTypeId.Invalid
+		}
+		const info = this.types[id]
+		if (!info) {
+			return BuiltinTypeId.Invalid
+		}
+		if (info.kind === TypeKind.Distinct) {
+			// Recursively unwrap (handles nested distinct types)
+			return this.toWasmType(info.underlying)
+		}
+		return id
+	}
+
+	count(): number {
+		return this.types.length
+	}
+
+	isValid(id: TypeId): boolean {
+		return id >= 0 && id < this.types.length
+	}
+
+	*[Symbol.iterator](): Generator<[TypeId, TypeInfo]> {
+		for (let i = 0; i < this.types.length; i++) {
+			const info = this.types[i]
+			if (info !== undefined) yield [typeId(i), info]
 		}
 	}
 }

--- a/packages/compiler/src/core/nodes.ts
+++ b/packages/compiler/src/core/nodes.ts
@@ -12,23 +12,23 @@ import type { TokenId } from './tokens.ts'
  */
 export const NodeKind = {
 	DedentLine: 1,
+
+	// Expressions (100-149)
+	Identifier: 100,
 	// Line types (0-9)
 	IndentedLine: 0,
+	IntLiteral: 101,
 
 	// Statements (10-99)
 	PanicStatement: 10,
 
-	// Future: Expressions (100-149)
-	// IntegerLiteral: 100,
-	// BinaryExpr: 101,
-
-	// Future: Declarations (150-199)
-	// FunctionDecl: 150,
-	// VariableDecl: 151,
-
 	// Program root (255)
 	Program: 255,
 	RootLine: 2,
+
+	// Type annotations (150-199)
+	TypeAnnotation: 150,
+	VariableBinding: 11,
 } as const
 
 export type NodeKind = (typeof NodeKind)[keyof typeof NodeKind]

--- a/packages/compiler/src/core/tokens.ts
+++ b/packages/compiler/src/core/tokens.ts
@@ -8,17 +8,23 @@
  * Grouped by category for clarity.
  */
 export const TokenKind = {
+	Colon: 3,
 	Dedent: 1,
-
-	// Future: Identifiers and literals (100-199)
-	// Identifier: 100,
-	// IntLiteral: 101,
-	// StringLiteral: 102,
+	// StringLiteral: 102, // Future
 
 	// Special (255)
 	Eof: 255,
+	Equals: 4,
+	F32: 13,
+	F64: 14,
+	I32: 11,
+	I64: 12,
+
+	// Identifiers and literals (100-199)
+	Identifier: 100,
 	// Structural tokens (0-9)
 	Indent: 0,
+	IntLiteral: 101,
 	Newline: 2,
 
 	// Keywords (10-99)

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -14,6 +14,7 @@ import { tokenize } from './lex/tokenizer.ts'
 import { parse } from './parse/parser.ts'
 
 export {
+	BuiltinTypeId,
 	type CheckResult,
 	check,
 	type Inst,
@@ -26,6 +27,9 @@ export {
 	ScopeStore,
 	scopeId,
 	type TypeId,
+	type TypeInfo,
+	TypeKind,
+	TypeStore,
 	typeId,
 } from './check/index.ts'
 export {

--- a/packages/compiler/src/parse/parser.ts
+++ b/packages/compiler/src/parse/parser.ts
@@ -11,7 +11,10 @@ export interface ParseResult {
 	rootNode?: NodeId
 }
 
-function tokenToOhmString(token: import('../core/tokens.ts').Token): string | null {
+function tokenToOhmString(
+	token: import('../core/tokens.ts').Token,
+	context: CompilationContext
+): string | null {
 	switch (token.kind) {
 		case TokenKind.Indent:
 			return `⇥${token.payload}`
@@ -19,6 +22,22 @@ function tokenToOhmString(token: import('../core/tokens.ts').Token): string | nu
 			return `⇤${token.payload}`
 		case TokenKind.Panic:
 			return 'panic'
+		case TokenKind.I32:
+			return 'i32'
+		case TokenKind.I64:
+			return 'i64'
+		case TokenKind.F32:
+			return 'f32'
+		case TokenKind.F64:
+			return 'f64'
+		case TokenKind.Identifier:
+			return context.strings.get(token.payload as import('../core/context.ts').StringId)
+		case TokenKind.IntLiteral:
+			return String(token.payload)
+		case TokenKind.Colon:
+			return ':'
+		case TokenKind.Equals:
+			return '='
 		default:
 			return null
 	}
@@ -36,8 +55,8 @@ function tokensToOhmInput(context: CompilationContext): string {
 		parts.push(generateNewlines(currentLine, token.line))
 		currentLine = token.line
 
-		const str = tokenToOhmString(token)
-		if (str !== null) parts.push(str)
+		const str = tokenToOhmString(token, context)
+		if (str !== null) parts.push(str, ' ')
 	}
 
 	return parts.join('')
@@ -46,22 +65,48 @@ function tokensToOhmInput(context: CompilationContext): string {
 interface TokenMapping {
 	positionToToken: Map<string, TokenId>
 	lineToFirstToken: Map<number, TokenId>
+	/** Map from Ohm string position to token ID */
+	ohmPositionToToken: Map<number, TokenId>
+}
+
+interface TokenMappingState {
+	ohmPosition: number
+	currentLine: number
+}
+
+function updateOhmPosition(
+	token: import('../core/tokens.ts').Token,
+	state: TokenMappingState,
+	ohmPositionToToken: Map<number, TokenId>,
+	id: TokenId,
+	context: CompilationContext
+): void {
+	const newlineCount = token.line - state.currentLine
+	state.ohmPosition += newlineCount
+	state.currentLine = token.line
+
+	const str = tokenToOhmString(token, context)
+	if (str !== null) {
+		ohmPositionToToken.set(state.ohmPosition, id)
+		state.ohmPosition += str.length + 1
+	}
 }
 
 function buildTokenMapping(context: CompilationContext): TokenMapping {
 	const positionToToken = new Map<string, TokenId>()
 	const lineToFirstToken = new Map<number, TokenId>()
+	const ohmPositionToToken = new Map<number, TokenId>()
+	const state: TokenMappingState = { currentLine: 1, ohmPosition: 0 }
 
 	for (const [id, token] of context.tokens) {
-		const key = `${token.line}:${token.column}`
-		positionToToken.set(key, id)
-
+		positionToToken.set(`${token.line}:${token.column}`, id)
 		if (!lineToFirstToken.has(token.line)) {
 			lineToFirstToken.set(token.line, id)
 		}
+		updateOhmPosition(token, state, ohmPositionToToken, id, context)
 	}
 
-	return { lineToFirstToken, positionToToken }
+	return { lineToFirstToken, ohmPositionToToken, positionToToken }
 }
 
 function createNodeEmittingSemantics(
@@ -81,12 +126,60 @@ function createNodeEmittingSemantics(
 		return tokenMapping.lineToFirstToken.get(lineNumber) ?? tokenId(0)
 	}
 
+	function findClosestPosition(targetIdx: number): TokenId {
+		const entries = Array.from(tokenMapping.ohmPositionToToken.entries())
+		const valid = entries.filter(([pos]) => pos <= targetIdx)
+		if (valid.length === 0) return tokenId(0)
+		const closest = valid.reduce((a, b) => (a[0] > b[0] ? a : b))
+		return closest[1]
+	}
+
+	function getTokenIdForOhmNode(node: Node): TokenId {
+		return findClosestPosition(node.source.startIdx)
+	}
+
 	semantics.addOperation<number>('toLevel', {
 		dedentToken(_marker: Node, levelDigits: Node) {
 			return Number(levelDigits.sourceString)
 		},
 		indentToken(_marker: Node, levelDigits: Node) {
 			return Number(levelDigits.sourceString)
+		},
+	})
+
+	// Emit expression nodes (leaves in postorder)
+	semantics.addOperation<NodeId>('emitExpression', {
+		Expression(expr: Node): NodeId {
+			return expr['emitExpression']()
+		},
+		identifier(_firstChar: Node, _restChars: Node): NodeId {
+			const tid = getTokenIdForOhmNode(this)
+			return context.nodes.add({
+				kind: NodeKind.Identifier,
+				subtreeSize: 1,
+				tokenId: tid,
+			})
+		},
+		intLiteral(_digits: Node): NodeId {
+			const tid = getTokenIdForOhmNode(this)
+			return context.nodes.add({
+				kind: NodeKind.IntLiteral,
+				subtreeSize: 1,
+				tokenId: tid,
+			})
+		},
+	})
+
+	// Emit type annotation nodes
+	semantics.addOperation<NodeId>('emitTypeAnnotation', {
+		TypeAnnotation(_colon: Node, typeName: Node): NodeId {
+			// Use the typeName's Ohm position to find the correct type keyword token
+			const tid = getTokenIdForOhmNode(typeName)
+			return context.nodes.add({
+				kind: NodeKind.TypeAnnotation,
+				subtreeSize: 1,
+				tokenId: tid,
+			})
 		},
 	})
 
@@ -104,18 +197,36 @@ function createNodeEmittingSemantics(
 		Statement(stmt: Node): NodeId {
 			return stmt['emitStatement']()
 		},
+		VariableBinding(ident: Node, typeAnnotation: Node, _equals: Node, expr: Node): NodeId {
+			// Emit children first (postorder: children before parent)
+			ident['emitExpression']()
+			typeAnnotation['emitTypeAnnotation']()
+			expr['emitExpression']()
+
+			const lineNumber = getLineNumber(this)
+			const tid = getTokenIdForLine(lineNumber)
+
+			// subtreeSize = 1 (self) + 3 children
+			return context.nodes.add({
+				kind: NodeKind.VariableBinding,
+				subtreeSize: 4,
+				tokenId: tid,
+			})
+		},
 	})
 
 	semantics.addOperation<NodeId | null>('emitLine', {
 		DedentLine(_dedentTokens: Node, optionalStatement: Node) {
 			const lineNumber = getLineNumber(this)
+			const startCount = context.nodes.count()
 
 			const stmtNode = optionalStatement.children[0]
-			let subtreeSize = 1
 			if (stmtNode !== undefined) {
 				stmtNode['emitStatement']()
-				subtreeSize = 2
 			}
+
+			const childCount = context.nodes.count() - startCount
+			const subtreeSize = 1 + childCount
 
 			const tid = getTokenIdForLine(lineNumber)
 			return context.nodes.add({
@@ -126,13 +237,15 @@ function createNodeEmittingSemantics(
 		},
 		IndentedLine(_indentToken: Node, optionalStatement: Node) {
 			const lineNumber = getLineNumber(this)
+			const startCount = context.nodes.count()
 
 			const stmtNode = optionalStatement.children[0]
-			let subtreeSize = 1
 			if (stmtNode !== undefined) {
 				stmtNode['emitStatement']()
-				subtreeSize = 2
 			}
+
+			const childCount = context.nodes.count() - startCount
+			const subtreeSize = 1 + childCount
 
 			const tid = getTokenIdForLine(lineNumber)
 			return context.nodes.add({
@@ -142,14 +255,16 @@ function createNodeEmittingSemantics(
 			})
 		},
 		RootLine(statement: Node) {
+			const startCount = context.nodes.count()
 			statement['emitStatement']()
+			const childCount = context.nodes.count() - startCount
 
 			const lineNumber = getLineNumber(this)
 			const tid = getTokenIdForLine(lineNumber)
 
 			return context.nodes.add({
 				kind: NodeKind.RootLine,
-				subtreeSize: 2,
+				subtreeSize: 1 + childCount,
 				tokenId: tid,
 			})
 		},

--- a/packages/compiler/src/parse/tinywhale.ohm
+++ b/packages/compiler/src/parse/tinywhale.ohm
@@ -7,13 +7,32 @@ TinyWhale {
   RootLine = Statement
 
   // Statements
-  Statement = PanicStatement
+  Statement = VariableBinding | PanicStatement
   PanicStatement = panic
 
+  // Variable binding: x:i32 = expr (with optional spaces)
+  VariableBinding = identifier TypeAnnotation equals Expression
+  TypeAnnotation = colon TypeName
+  TypeName = typeKeyword
+
+  // Expressions
+  Expression = identifier | intLiteral
+
   // Keywords
-  keyword = panic
+  keyword = panic | typeKeyword
+  typeKeyword = i32 | i64 | f32 | f64
   panic = "panic" ~identifierPart
+  i32 = "i32" ~identifierPart
+  i64 = "i64" ~identifierPart
+  f32 = "f32" ~identifierPart
+  f64 = "f64" ~identifierPart
   identifierPart = alnum | "_"
+
+  // Identifiers and literals (from tokenizer)
+  identifier = ~keyword letter (alnum | "_")*
+  intLiteral = digit+
+  colon = ":"
+  equals = "="
 
   // Lexical token rules (marker followed by indent level)
   indentToken = "⇥" digit+

--- a/packages/compiler/test/check/bindings.test.ts
+++ b/packages/compiler/test/check/bindings.test.ts
@@ -1,0 +1,182 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+
+import { check } from '../../src/check/checker.ts'
+import { InstKind } from '../../src/check/types.ts'
+import { CompilationContext } from '../../src/core/context.ts'
+import { compile } from '../../src/index.ts'
+import { tokenize } from '../../src/lex/tokenizer.ts'
+import { parse } from '../../src/parse/parser.ts'
+
+function compileAndCheck(source: string): CompilationContext {
+	const ctx = new CompilationContext(source)
+	tokenize(ctx)
+	parse(ctx)
+	check(ctx)
+	return ctx
+}
+
+describe('check/variable bindings', () => {
+	describe('basic binding', () => {
+		it('should compile x:i32 = 0 successfully', () => {
+			const ctx = compileAndCheck('x:i32 = 0\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+			assert.ok(ctx.symbols)
+			assert.strictEqual(ctx.symbols.count(), 1)
+		})
+
+		it('should compile x:i64 = 100 with i64 literal', () => {
+			const ctx = compileAndCheck('x:i64 = 100\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+			assert.ok(ctx.symbols)
+			const symbol = ctx.symbols.get(0 as import('../../src/check/types.ts').SymbolId)
+			assert.strictEqual(symbol.typeId, 2) // BuiltinTypeId.I64
+		})
+
+		it('should allow spaces around colon', () => {
+			const ctx = compileAndCheck('x : i32 = 0\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should emit Bind instruction', () => {
+			const ctx = compileAndCheck('x:i32 = 0\n')
+			assert.ok(ctx.insts)
+			// Should have IntConst and Bind
+			let hasBind = false
+			for (const [, inst] of ctx.insts) {
+				if (inst.kind === InstKind.Bind) hasBind = true
+			}
+			assert.ok(hasBind)
+		})
+
+		it('should emit IntConst instruction', () => {
+			const ctx = compileAndCheck('x:i32 = 42\n')
+			assert.ok(ctx.insts)
+			let hasIntConst = false
+			for (const [, inst] of ctx.insts) {
+				if (inst.kind === InstKind.IntConst) {
+					hasIntConst = true
+					assert.strictEqual(inst.arg0, 42)
+				}
+			}
+			assert.ok(hasIntConst)
+		})
+	})
+
+	describe('variable references', () => {
+		it('should compile y:i32 = x when x is defined', () => {
+			const ctx = compileAndCheck('x:i32 = 0\ny:i32 = x\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+			assert.ok(ctx.symbols)
+			assert.strictEqual(ctx.symbols.count(), 2)
+		})
+
+		it('should emit VarRef instruction for variable reference', () => {
+			const ctx = compileAndCheck('x:i32 = 0\ny:i32 = x\n')
+			assert.ok(ctx.insts)
+			let hasVarRef = false
+			for (const [, inst] of ctx.insts) {
+				if (inst.kind === InstKind.VarRef) hasVarRef = true
+			}
+			assert.ok(hasVarRef)
+		})
+
+		it('should error on undefined variable', () => {
+			const ctx = compileAndCheck('x:i32 = y\n')
+			assert.strictEqual(ctx.hasErrors(), true)
+			const errors = ctx.getErrors()
+			assert.ok(errors.some((e) => e.message.includes('undefined variable')))
+		})
+	})
+
+	describe('type checking', () => {
+		it('should error on type mismatch', () => {
+			const ctx = compileAndCheck('x:i64 = 0\ny:i32 = x\n')
+			assert.strictEqual(ctx.hasErrors(), true)
+			const errors = ctx.getErrors()
+			assert.ok(errors.some((e) => e.message.includes('type mismatch')))
+		})
+
+		it('should allow same type assignment', () => {
+			const ctx = compileAndCheck('x:i32 = 0\ny:i32 = x\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+	})
+
+	describe('shadowing', () => {
+		it('should allow rebinding same name with same type', () => {
+			const ctx = compileAndCheck('x:i32 = 0\nx:i32 = 1\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+			assert.ok(ctx.symbols)
+			assert.strictEqual(ctx.symbols.count(), 2) // Two distinct locals
+		})
+
+		it('should create fresh local for each binding', () => {
+			const ctx = compileAndCheck('x:i32 = 0\nx:i32 = 1\n')
+			assert.ok(ctx.symbols)
+			const sym0 = ctx.symbols.get(0 as import('../../src/check/types.ts').SymbolId)
+			const sym1 = ctx.symbols.get(1 as import('../../src/check/types.ts').SymbolId)
+			assert.strictEqual(sym0.localIndex, 0)
+			assert.strictEqual(sym1.localIndex, 1)
+		})
+
+		it('should allow self-reference in shadowing', () => {
+			const ctx = compileAndCheck('x:i32 = 0\nx:i32 = x\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+			assert.ok(ctx.symbols)
+			assert.strictEqual(ctx.symbols.count(), 2)
+		})
+	})
+
+	describe('codegen integration', () => {
+		it('should compile binding to valid WASM', () => {
+			const result = compile('x:i32 = 42\npanic\n')
+			assert.strictEqual(result.valid, true)
+			// Check for local.set in WAT output
+			assert.ok(result.text.includes('local.set'))
+		})
+
+		it('should include locals declaration', () => {
+			const result = compile('x:i32 = 0\npanic\n')
+			assert.strictEqual(result.valid, true)
+			// Check for local declaration
+			assert.ok(result.text.includes('(local'))
+		})
+
+		it('should compile reference to valid WASM', () => {
+			const result = compile('x:i32 = 0\ny:i32 = x\npanic\n')
+			assert.strictEqual(result.valid, true)
+			// Check for local.get in WAT output
+			assert.ok(result.text.includes('local.get'))
+		})
+
+		it('should compile shadowing to valid WASM', () => {
+			const result = compile('x:i32 = 0\nx:i32 = x\npanic\n')
+			assert.strictEqual(result.valid, true)
+		})
+	})
+
+	describe('error cases', () => {
+		it('should error on unknown type', () => {
+			// This would need a different type name but our tokenizer
+			// only recognizes i32, i64, f32, f64 as type keywords
+			// So this test would require an identifier as type which we don't support
+		})
+
+		it('should report correct error location for undefined variable', () => {
+			const ctx = compileAndCheck('x:i32 = undefined_var\n')
+			assert.strictEqual(ctx.hasErrors(), true)
+			const errors = ctx.getErrors()
+			assert.strictEqual(errors.length, 1)
+			assert.strictEqual(errors[0]?.line, 1)
+		})
+
+		it('should report correct error location for type mismatch', () => {
+			const ctx = compileAndCheck('x:i64 = 0\ny:i32 = x\n')
+			assert.strictEqual(ctx.hasErrors(), true)
+			const errors = ctx.getErrors()
+			assert.strictEqual(errors.length, 1)
+			assert.strictEqual(errors[0]?.line, 2)
+		})
+	})
+})

--- a/packages/compiler/test/check/bindings.test.ts
+++ b/packages/compiler/test/check/bindings.test.ts
@@ -103,6 +103,36 @@ describe('check/variable bindings', () => {
 		})
 	})
 
+	describe('float bindings', () => {
+		it('should compile x:f32 = 0 successfully', () => {
+			const ctx = compileAndCheck('x:f32 = 0\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+			assert.ok(ctx.symbols)
+			const symbol = ctx.symbols.get(0 as import('../../src/check/types.ts').SymbolId)
+			assert.strictEqual(symbol.typeId, 3) // BuiltinTypeId.F32
+		})
+
+		it('should compile x:f64 = 0 successfully', () => {
+			const ctx = compileAndCheck('x:f64 = 0\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+			assert.ok(ctx.symbols)
+			const symbol = ctx.symbols.get(0 as import('../../src/check/types.ts').SymbolId)
+			assert.strictEqual(symbol.typeId, 4) // BuiltinTypeId.F64
+		})
+
+		it('should error on f32/f64 type mismatch', () => {
+			const ctx = compileAndCheck('x:f32 = 0\ny:f64 = x\n')
+			assert.strictEqual(ctx.hasErrors(), true)
+			const errors = ctx.getErrors()
+			assert.ok(errors.some((e) => e.message.includes('type mismatch')))
+		})
+
+		it('should allow same float type assignment', () => {
+			const ctx = compileAndCheck('x:f32 = 0\ny:f32 = x\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+	})
+
 	describe('shadowing', () => {
 		it('should allow rebinding same name with same type', () => {
 			const ctx = compileAndCheck('x:i32 = 0\nx:i32 = 1\n')

--- a/packages/compiler/test/check/types.test.ts
+++ b/packages/compiler/test/check/types.test.ts
@@ -1,0 +1,291 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { TypeStore } from '../../src/check/stores.ts'
+import { BuiltinTypeId, type TypeInfo, TypeKind, typeId } from '../../src/check/types.ts'
+import { nodeId } from '../../src/core/nodes.ts'
+
+describe('check/TypeKind', () => {
+	it('should have correct values for None', () => {
+		assert.strictEqual(TypeKind.None, 0)
+	})
+
+	it('should have correct values for WASM primitives', () => {
+		assert.strictEqual(TypeKind.I32, 1)
+		assert.strictEqual(TypeKind.I64, 2)
+		assert.strictEqual(TypeKind.F32, 3)
+		assert.strictEqual(TypeKind.F64, 4)
+	})
+
+	it('should have correct value for Distinct', () => {
+		assert.strictEqual(TypeKind.Distinct, 5)
+	})
+})
+
+describe('check/BuiltinTypeId', () => {
+	it('should have Invalid at -1', () => {
+		assert.strictEqual(BuiltinTypeId.Invalid, -1)
+	})
+
+	it('should have None at index 0', () => {
+		assert.strictEqual(BuiltinTypeId.None, 0)
+	})
+
+	it('should have WASM primitives at indices 1-4', () => {
+		assert.strictEqual(BuiltinTypeId.I32, 1)
+		assert.strictEqual(BuiltinTypeId.I64, 2)
+		assert.strictEqual(BuiltinTypeId.F32, 3)
+		assert.strictEqual(BuiltinTypeId.F64, 4)
+	})
+})
+
+describe('check/typeId', () => {
+	it('should create TypeId from number', () => {
+		const id = typeId(5)
+		assert.strictEqual(id, 5)
+	})
+})
+
+describe('check/TypeStore', () => {
+	describe('primitive bootstrapping', () => {
+		it('should initialize with 5 builtin types', () => {
+			const store = new TypeStore()
+			assert.strictEqual(store.count(), 5)
+		})
+
+		it('should have none at index 0', () => {
+			const store = new TypeStore()
+			const info = store.get(BuiltinTypeId.None)
+			assert.strictEqual(info.kind, TypeKind.None)
+			assert.strictEqual(info.name, 'none')
+		})
+
+		it('should have i32 at index 1', () => {
+			const store = new TypeStore()
+			const info = store.get(BuiltinTypeId.I32)
+			assert.strictEqual(info.kind, TypeKind.I32)
+			assert.strictEqual(info.name, 'i32')
+		})
+
+		it('should have i64 at index 2', () => {
+			const store = new TypeStore()
+			const info = store.get(BuiltinTypeId.I64)
+			assert.strictEqual(info.kind, TypeKind.I64)
+			assert.strictEqual(info.name, 'i64')
+		})
+
+		it('should have f32 at index 3', () => {
+			const store = new TypeStore()
+			const info = store.get(BuiltinTypeId.F32)
+			assert.strictEqual(info.kind, TypeKind.F32)
+			assert.strictEqual(info.name, 'f32')
+		})
+
+		it('should have f64 at index 4', () => {
+			const store = new TypeStore()
+			const info = store.get(BuiltinTypeId.F64)
+			assert.strictEqual(info.kind, TypeKind.F64)
+			assert.strictEqual(info.name, 'f64')
+		})
+
+		it('should lookup primitives by name', () => {
+			const store = new TypeStore()
+			assert.strictEqual(store.lookup('i32'), BuiltinTypeId.I32)
+			assert.strictEqual(store.lookup('i64'), BuiltinTypeId.I64)
+			assert.strictEqual(store.lookup('f32'), BuiltinTypeId.F32)
+			assert.strictEqual(store.lookup('f64'), BuiltinTypeId.F64)
+			assert.strictEqual(store.lookup('none'), BuiltinTypeId.None)
+		})
+
+		it('should return undefined for unknown names', () => {
+			const store = new TypeStore()
+			assert.strictEqual(store.lookup('unknown'), undefined)
+		})
+
+		it('builtins should self-reference as underlying', () => {
+			const store = new TypeStore()
+			const i32Info = store.get(BuiltinTypeId.I32)
+			assert.strictEqual(i32Info.underlying, BuiltinTypeId.I32)
+		})
+
+		it('builtins should have null parseNodeId', () => {
+			const store = new TypeStore()
+			const i32Info = store.get(BuiltinTypeId.I32)
+			assert.strictEqual(i32Info.parseNodeId, null)
+		})
+	})
+
+	describe('distinct types', () => {
+		it('should create new TypeId for distinct type', () => {
+			const store = new TypeStore()
+			const distinctId = store.declareDistinct('UserId', BuiltinTypeId.I32, nodeId(0))
+
+			assert.notStrictEqual(distinctId, BuiltinTypeId.I32)
+			assert.strictEqual(store.count(), 6)
+		})
+
+		it('should track underlying type', () => {
+			const store = new TypeStore()
+			const distinctId = store.declareDistinct('UserId', BuiltinTypeId.I32, nodeId(0))
+			const info = store.get(distinctId)
+
+			assert.strictEqual(info.kind, TypeKind.Distinct)
+			assert.strictEqual(info.underlying, BuiltinTypeId.I32)
+		})
+
+		it('should be lookupable by name', () => {
+			const store = new TypeStore()
+			const distinctId = store.declareDistinct('UserId', BuiltinTypeId.I32, nodeId(0))
+
+			assert.strictEqual(store.lookup('UserId'), distinctId)
+		})
+
+		it('should store parseNodeId', () => {
+			const store = new TypeStore()
+			const distinctId = store.declareDistinct('UserId', BuiltinTypeId.I32, nodeId(42))
+			const info = store.get(distinctId)
+
+			assert.strictEqual(info.parseNodeId, 42)
+		})
+
+		it('different wrappers should have different TypeIds', () => {
+			const store = new TypeStore()
+			const userId = store.declareDistinct('UserId', BuiltinTypeId.I32, nodeId(0))
+			const groupId = store.declareDistinct('GroupId', BuiltinTypeId.I32, nodeId(1))
+
+			assert.notStrictEqual(userId, groupId)
+			assert.notStrictEqual(userId, BuiltinTypeId.I32)
+			assert.notStrictEqual(groupId, BuiltinTypeId.I32)
+		})
+	})
+
+	describe('type equality', () => {
+		it('should return true for same TypeId', () => {
+			const store = new TypeStore()
+			assert.strictEqual(store.areEqual(BuiltinTypeId.I32, BuiltinTypeId.I32), true)
+		})
+
+		it('should return false for different TypeIds', () => {
+			const store = new TypeStore()
+			assert.strictEqual(store.areEqual(BuiltinTypeId.I32, BuiltinTypeId.I64), false)
+		})
+
+		it('should distinguish distinct from underlying', () => {
+			const store = new TypeStore()
+			const distinctId = store.declareDistinct('UserId', BuiltinTypeId.I32, nodeId(0))
+
+			assert.strictEqual(store.areEqual(distinctId, BuiltinTypeId.I32), false)
+		})
+
+		it('should distinguish different distinct types', () => {
+			const store = new TypeStore()
+			const userId = store.declareDistinct('UserId', BuiltinTypeId.I32, nodeId(0))
+			const groupId = store.declareDistinct('GroupId', BuiltinTypeId.I32, nodeId(1))
+
+			assert.strictEqual(store.areEqual(userId, groupId), false)
+		})
+	})
+
+	describe('toWasmType', () => {
+		it('should return primitive unchanged', () => {
+			const store = new TypeStore()
+			assert.strictEqual(store.toWasmType(BuiltinTypeId.I32), BuiltinTypeId.I32)
+			assert.strictEqual(store.toWasmType(BuiltinTypeId.F64), BuiltinTypeId.F64)
+		})
+
+		it('should unwrap distinct to underlying', () => {
+			const store = new TypeStore()
+			const distinctId = store.declareDistinct('UserId', BuiltinTypeId.I32, nodeId(0))
+
+			assert.strictEqual(store.toWasmType(distinctId), BuiltinTypeId.I32)
+		})
+
+		it('should recursively unwrap nested distinct', () => {
+			const store = new TypeStore()
+			const level1 = store.declareDistinct('Level1', BuiltinTypeId.F64, nodeId(0))
+			const level2 = store.declareDistinct('Level2', level1, nodeId(1))
+
+			assert.strictEqual(store.toWasmType(level2), BuiltinTypeId.F64)
+		})
+
+		it('should return Invalid for Invalid sentinel', () => {
+			const store = new TypeStore()
+			assert.strictEqual(store.toWasmType(BuiltinTypeId.Invalid), BuiltinTypeId.Invalid)
+		})
+	})
+
+	describe('typeName', () => {
+		it('should return primitive names', () => {
+			const store = new TypeStore()
+			assert.strictEqual(store.typeName(BuiltinTypeId.I32), 'i32')
+			assert.strictEqual(store.typeName(BuiltinTypeId.None), 'none')
+		})
+
+		it('should return distinct type name', () => {
+			const store = new TypeStore()
+			const distinctId = store.declareDistinct('UserId', BuiltinTypeId.I32, nodeId(0))
+			assert.strictEqual(store.typeName(distinctId), 'UserId')
+		})
+
+		it('should return <invalid> for Invalid sentinel', () => {
+			const store = new TypeStore()
+			assert.strictEqual(store.typeName(BuiltinTypeId.Invalid), '<invalid>')
+		})
+	})
+
+	describe('error handling', () => {
+		it('should throw for invalid TypeId', () => {
+			const store = new TypeStore()
+			assert.throws(() => store.get(typeId(100)), /Invalid TypeId/)
+		})
+
+		it('should throw when getting Invalid sentinel', () => {
+			const store = new TypeStore()
+			assert.throws(() => store.get(BuiltinTypeId.Invalid), /Invalid sentinel/)
+		})
+	})
+
+	describe('validation', () => {
+		it('should validate builtin IDs', () => {
+			const store = new TypeStore()
+			assert.strictEqual(store.isValid(BuiltinTypeId.None), true)
+			assert.strictEqual(store.isValid(BuiltinTypeId.I32), true)
+			assert.strictEqual(store.isValid(BuiltinTypeId.F64), true)
+		})
+
+		it('should invalidate out-of-range IDs', () => {
+			const store = new TypeStore()
+			assert.strictEqual(store.isValid(typeId(100)), false)
+			assert.strictEqual(store.isValid(typeId(-1)), false)
+		})
+	})
+
+	describe('iteration', () => {
+		it('should iterate over all types', () => {
+			const store = new TypeStore()
+			const types: Array<[number, TypeInfo]> = []
+
+			for (const [id, info] of store) {
+				types.push([id, info])
+			}
+
+			assert.strictEqual(types.length, 5)
+			assert.strictEqual(types[0]?.[0], 0)
+			assert.strictEqual(types[0]?.[1].name, 'none')
+			assert.strictEqual(types[1]?.[0], 1)
+			assert.strictEqual(types[1]?.[1].name, 'i32')
+		})
+
+		it('should include distinct types in iteration', () => {
+			const store = new TypeStore()
+			store.declareDistinct('UserId', BuiltinTypeId.I32, nodeId(0))
+
+			const types: Array<[number, TypeInfo]> = []
+			for (const [id, info] of store) {
+				types.push([id, info])
+			}
+
+			assert.strictEqual(types.length, 6)
+			assert.strictEqual(types[5]?.[1].name, 'UserId')
+		})
+	})
+})

--- a/packages/compiler/test/codegen.test.ts
+++ b/packages/compiler/test/codegen.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 
+import { check } from '../src/check/checker.ts'
 import { CompileError, type CompileResult, emit } from '../src/codegen/index.ts'
 import { CompilationContext } from '../src/core/context.ts'
 import { tokenize } from '../src/lex/tokenizer.ts'
@@ -10,6 +11,7 @@ function compileSource(source: string, optimize = false): CompileResult {
 	const ctx = new CompilationContext(source)
 	tokenize(ctx)
 	parse(ctx)
+	check(ctx)
 	return emit(ctx, { optimize })
 }
 
@@ -46,6 +48,7 @@ describe('codegen', () => {
 			const ctx = new CompilationContext('\n')
 			tokenize(ctx)
 			parse(ctx)
+			check(ctx)
 
 			assert.throws(
 				() => emit(ctx),
@@ -61,6 +64,7 @@ describe('codegen', () => {
 			const ctx = new CompilationContext('# just a comment\n')
 			tokenize(ctx)
 			parse(ctx)
+			check(ctx)
 
 			assert.throws(
 				() => emit(ctx),

--- a/packages/diagnostics/src/compiler.ts
+++ b/packages/diagnostics/src/compiler.ts
@@ -83,6 +83,38 @@ export const TWCHECK001: DiagnosticDef = {
 		'Remove the indentation, or wrap this code in a function when that feature is available.',
 }
 
+export const TWCHECK010: DiagnosticDef = {
+	code: 'TWCHECK010',
+	description: 'The type name is not recognized.',
+	message: 'unknown type `{found}`',
+	severity: DiagnosticSeverity.Error,
+	suggestion: 'Valid types are: i32, i64, f32, f64',
+}
+
+export const TWCHECK012: DiagnosticDef = {
+	code: 'TWCHECK012',
+	description: 'The expression type does not match the declared type.',
+	message: 'type mismatch: expected `{expected}`, found `{found}`',
+	severity: DiagnosticSeverity.Error,
+	suggestion: 'Change the expression to produce a value of type `{expected}`.',
+}
+
+export const TWCHECK013: DiagnosticDef = {
+	code: 'TWCHECK013',
+	description: 'This variable has not been declared.',
+	message: 'undefined variable `{name}`',
+	severity: DiagnosticSeverity.Error,
+	suggestion: 'Declare the variable before using it.',
+}
+
+export const TWCHECK014: DiagnosticDef = {
+	code: 'TWCHECK014',
+	description: 'The integer literal value is too large for the declared type.',
+	message: 'integer literal `{value}` exceeds `{type}` bounds',
+	severity: DiagnosticSeverity.Error,
+	suggestion: 'Use a smaller value or a larger type.',
+}
+
 // =============================================================================
 // CHECKER WARNINGS (TWCHECK050-099)
 // =============================================================================
@@ -114,6 +146,10 @@ export const TWGEN001: DiagnosticDef = {
 
 export const COMPILER_DIAGNOSTICS = {
 	TWCHECK001,
+	TWCHECK010,
+	TWCHECK012,
+	TWCHECK013,
+	TWCHECK014,
 	TWCHECK050,
 	TWGEN001,
 	TWLEX001,


### PR DESCRIPTION
Implement variable binding syntax (x:i32 = expr) with full type checking:

- Grammar: variable bindings with type annotations (i32, i64, f32, f64)
- Lexer: identifier, intLiteral, colon, equals, and type keyword tokens
- Parser: VariableBinding, TypeAnnotation, and Expression nodes
- Checker: symbol table with shadowing, type store, name resolution
- Codegen: WASM local variables with proper type mapping
- Diagnostics: TWCHECK002 (type mismatch), TWCHECK003 (undefined variable)

Add example files: bindings.tw, references.tw, shadowing.tw