### PR TITLE
fix(cli): unify warning and error diagnostic format

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -45,10 +45,7 @@ export default class BuildCommand extends BaseCommand {
 
 	private displayWarnings(warnings: CompileWarning[]): void {
 		for (const warning of warnings) {
-			const codeDisplay = warning.code !== 'LEGACY' ? `[${warning.code}]` : ''
-			this.logger.warning(
-				`warning${codeDisplay}: ${warning.message}\n  --> ${this.input}:${warning.line}:${warning.column}`
-			)
+			this.logger.warning(warning.formattedMessage)
 		}
 	}
 

--- a/packages/compiler/src/codegen/index.ts
+++ b/packages/compiler/src/codegen/index.ts
@@ -20,6 +20,7 @@ export interface CompileWarning {
 	message: string
 	line: number
 	column: number
+	formattedMessage: string
 }
 
 export interface CompileResult {
@@ -216,6 +217,7 @@ function extractWarnings(context: CompilationContext): CompileWarning[] {
 		.map((d) => ({
 			code: d.def.code,
 			column: d.column,
+			formattedMessage: context.formatDiagnostic(d),
 			line: d.line,
 			message: d.message,
 		}))

--- a/packages/compiler/test/check/checker.test.ts
+++ b/packages/compiler/test/check/checker.test.ts
@@ -75,13 +75,13 @@ describe('check/checker', () => {
 			assert.ok(warnings[0]?.message.includes('unreachable'))
 		})
 
-		it('should warn for all code after panic', () => {
+		it('should group consecutive unreachable code into one warning', () => {
 			const ctx = prepareContext('panic\npanic\npanic\n')
 			const result = check(ctx)
 
 			assert.strictEqual(result.succeeded, true)
 			const warnings = getWarnings(ctx)
-			assert.strictEqual(warnings.length, 2)
+			assert.strictEqual(warnings.length, 1) // Grouped into single warning
 		})
 
 		it('should report correct line for unreachable code', () => {
@@ -92,13 +92,16 @@ describe('check/checker', () => {
 			assert.strictEqual(warnings[0]?.line, 2)
 		})
 
-		it('should report correct line for multiple unreachable', () => {
+		it('should include line range in grouped unreachable warning', () => {
 			const ctx = prepareContext('panic\npanic\npanic\n')
 			check(ctx)
 
 			const warnings = getWarnings(ctx)
-			assert.strictEqual(warnings[0]?.line, 2)
-			assert.strictEqual(warnings[1]?.line, 3)
+			assert.strictEqual(warnings.length, 1)
+			assert.strictEqual(warnings[0]?.line, 2) // First unreachable line
+			// Check that the formatted message includes the range
+			const formatted = ctx.formatDiagnostic(warnings[0]!)
+			assert.ok(formatted.includes('Lines 2-3'))
 		})
 	})
 


### PR DESCRIPTION
Warnings now display with the same format as errors, including source line, caret pointer, and help text.