### PR TITLE
refactor(compiler): remove deprecated diagnostic API

### DIFF
--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -20,6 +20,7 @@ export function getErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error)
 }
 
+/** Special-cases ENOENT for clearer "file not found" UX vs generic I/O errors. */
 export function formatReadError(filePath: string, error: unknown): string {
 	if (isNodeError(error) && error.code === 'ENOENT') {
 		const message = interpolateMessage(TWCLI001.message, { path: filePath })
@@ -43,6 +44,7 @@ export function formatValidationError(): string {
 	return `[${TWCLI005.code}] ${TWCLI005.message}`
 }
 
+/** Preserves CompileError message (contains formatted diagnostics), wraps other errors. */
 export function formatCompileError(error: unknown): string {
 	if (error instanceof CompileError) {
 		return error.message

--- a/packages/compiler/src/core/diagnostics.ts
+++ b/packages/compiler/src/core/diagnostics.ts
@@ -2,8 +2,8 @@
  * Re-export diagnostic types and compiler definitions from shared package.
  */
 
-// Types and utilities
-// Compiler diagnostics
+import { COMPILER_DIAGNOSTICS } from '@tinywhale/diagnostics'
+
 export {
 	COMPILER_DIAGNOSTICS,
 	type CompilerDiagnosticCode,
@@ -21,14 +21,6 @@ export {
 	TWLEX005,
 	TWPARSE001,
 } from '@tinywhale/diagnostics'
-
-// Re-export combined catalog for backwards compatibility
-import { COMPILER_DIAGNOSTICS } from '@tinywhale/diagnostics'
-
-/**
- * @deprecated Use COMPILER_DIAGNOSTICS or import directly from @tinywhale/diagnostics
- */
-export const DIAGNOSTICS = COMPILER_DIAGNOSTICS
 
 /**
  * All valid diagnostic codes for the compiler.

--- a/packages/compiler/src/core/index.ts
+++ b/packages/compiler/src/core/index.ts
@@ -8,7 +8,7 @@ export {
 	type Diagnostic,
 } from './context.ts'
 export {
-	DIAGNOSTICS,
+	COMPILER_DIAGNOSTICS,
 	type DiagnosticArgs,
 	type DiagnosticCode,
 	type DiagnosticDef,

--- a/packages/compiler/src/core/nodes.ts
+++ b/packages/compiler/src/core/nodes.ts
@@ -6,10 +6,7 @@
 
 import type { TokenId } from './tokens.ts'
 
-/**
- * Node kinds - one per grammar production.
- * Grouped by category for clarity.
- */
+/** Node kinds - one per grammar production. */
 export const NodeKind = {
 	DedentLine: 1,
 

--- a/packages/compiler/src/core/tokens.ts
+++ b/packages/compiler/src/core/tokens.ts
@@ -3,10 +3,7 @@
  * Carbon-style data-oriented design for cache efficiency.
  */
 
-/**
- * Token kinds - small integer discriminant.
- * Grouped by category for clarity.
- */
+/** Token kinds - small integer discriminant. */
 export const TokenKind = {
 	Colon: 3,
 	Dedent: 1,
@@ -33,10 +30,6 @@ export const TokenKind = {
 
 export type TokenKind = (typeof TokenKind)[keyof typeof TokenKind]
 
-/**
- * Branded type for token IDs.
- * Provides type safety while remaining a plain number at runtime.
- */
 export type TokenId = number & { readonly __brand: 'TokenId' }
 
 export function tokenId(n: number): TokenId {
@@ -93,6 +86,7 @@ export class TokenStore {
 		}
 	}
 
+	/** Returns tokens in range [start, end). */
 	slice(start: TokenId, end: TokenId): Token[] {
 		return this.tokens.slice(start, end)
 	}

--- a/packages/diagnostics/src/index.ts
+++ b/packages/diagnostics/src/index.ts
@@ -45,10 +45,12 @@ export const DIAGNOSTICS = {
 
 export type DiagnosticCode = keyof typeof DIAGNOSTICS
 
+/** Retrieves diagnostic definition by code. Returns undefined for invalid codes. */
 export function getDiagnostic(code: DiagnosticCode): (typeof DIAGNOSTICS)[typeof code] {
 	return DIAGNOSTICS[code]
 }
 
+/** Type guard for validating diagnostic codes at runtime. */
 export function isValidDiagnosticCode(code: string): code is DiagnosticCode {
 	return code in DIAGNOSTICS
 }


### PR DESCRIPTION
Remove diagnostic methods that were marked @deprecated:
  - addDiagnostic, addError, addWarning
  - errorAtToken, errorAtNode, warningAtNode
  - DIAGNOSTICS re-export (use COMPILER_DIAGNOSTICS instead)