### PR TITLE
feat(compiler): add runtime negation and scientific notation for inte…

### DIFF
--- a/examples/negation.tw
+++ b/examples/negation.tw
@@ -1,0 +1,8 @@
+# Runtime negation of variables
+x:i32 = 42
+y:i32 = -x     # y = -42 (runtime negation)
+
+a:f64 = 3.14
+b:f64 = -a     # b = -3.14 (uses f64.neg)
+
+panic

--- a/examples/scientific.tw
+++ b/examples/scientific.tw
@@ -1,0 +1,9 @@
+# Scientific notation for integers
+billion:i64 = 1e9          # 1,000,000,000
+trillion:i64 = 1e12        # 1,000,000,000,000
+
+# Float literals still require decimal point
+pi:f64 = 3.14159e0         # same as 3.14159
+tiny:f32 = 1.5e-10         # 0.00000000015
+
+panic

--- a/packages/compiler/src/check/types.ts
+++ b/packages/compiler/src/check/types.ts
@@ -32,18 +32,22 @@ export function symbolId(n: number): SymbolId {
 /**
  * Instruction kinds.
  * These represent semantic operations in the IR.
+ *
+ * Number ranges:
+ * - Terminators: 0-9
+ * - Constants: 10-19
+ * - Variables: 20-29
+ * - Operators: 30-39
  */
 export const InstKind = {
-	// Variables (20-29)
 	/** Variable binding: arg0 = SymbolId, arg1 = initializer InstId */
 	Bind: 20,
 	/** Float constant: arg0 = FloatId (index into FloatStore) */
 	FloatConst: 11,
-
-	// Constants (10-19)
 	/** Integer constant: arg0 = low 32 bits, arg1 = high 32 bits (for i64) */
 	IntConst: 10,
-	// Terminators (0-9)
+	/** Unary negation: arg0 = operand InstId */
+	Negate: 30,
 	/** panic - unconditional trap, terminates control flow */
 	Unreachable: 0,
 	/** Variable reference: arg0 = SymbolId */

--- a/packages/compiler/src/parse/parser.ts
+++ b/packages/compiler/src/parse/parser.ts
@@ -180,7 +180,7 @@ function createNodeEmittingSemantics(
 				tokenId: tid,
 			})
 		},
-		intLiteral(_digits: Node): NodeId {
+		intLiteral(_digits: Node, _expE: Node, _expSign: Node, _expDigits: Node): NodeId {
 			const tid = getTokenIdForOhmNode(this)
 			return context.nodes.add({
 				kind: NodeKind.IntLiteral,

--- a/packages/compiler/src/parse/tinywhale.ohm
+++ b/packages/compiler/src/parse/tinywhale.ohm
@@ -32,7 +32,7 @@ TinyWhale {
 
   // Identifiers and literals (from tokenizer)
   identifier = ~keyword letter (alnum | "_")*
-  intLiteral = digit+
+  intLiteral = digit+ (("e" | "E") ("+" | "-")? digit+)?
   floatLiteral = digit+ "." digit+ (("e" | "E") ("+" | "-")? digit+)?
   colon = ":"
   equals = "="


### PR DESCRIPTION
feat(compiler): add runtime negation and scientific notation for integers

  - Add InstKind.Negate for runtime variable negation (-x)
  - Support scientific notation for integer literals (1e10)
  - Remove implicit int→float conversion (x:f32 = 42 now errors)
  - Fix InstKind.FloatConst placement in types.ts