### PR TITLE
refactor(compiler): improve branded type safety across codebase

### DIFF
--- a/packages/compiler/src/check/stores.ts
+++ b/packages/compiler/src/check/stores.ts
@@ -109,7 +109,7 @@ export class ScopeStore {
 export class SymbolStore {
 	private readonly symbols: SymbolEntry[] = []
 	/** Current binding per name (overwrites on shadowing) */
-	private readonly nameToSymbol: Map<number, SymbolId> = new Map()
+	private readonly nameToSymbol: Map<StringId, SymbolId> = new Map()
 	/** Next WASM local index to allocate */
 	private nextLocalIndex = 0
 
@@ -123,7 +123,7 @@ export class SymbolStore {
 		const fullEntry: SymbolEntry = { ...entry, localIndex }
 		this.symbols.push(fullEntry)
 		// Overwrite previous binding (shadowing)
-		this.nameToSymbol.set(entry.nameId as number, id)
+		this.nameToSymbol.set(entry.nameId, id)
 		return id
 	}
 
@@ -132,7 +132,7 @@ export class SymbolStore {
 	 * Returns undefined if the name has not been bound.
 	 */
 	lookupByName(nameId: StringId): SymbolId | undefined {
-		return this.nameToSymbol.get(nameId as number)
+		return this.nameToSymbol.get(nameId)
 	}
 
 	/**

--- a/packages/compiler/src/check/types.ts
+++ b/packages/compiler/src/check/types.ts
@@ -3,6 +3,7 @@
  * Carbon-style data-oriented design with 16-byte instructions.
  */
 
+import type { FloatId, StringId } from '../core/context.ts'
 import type { NodeId } from '../core/nodes.ts'
 
 export type InstId = number & { readonly __brand: 'InstId' }
@@ -161,7 +162,7 @@ export interface Scope {
  */
 export interface SymbolEntry {
 	/** Interned name of the symbol */
-	readonly nameId: import('../core/context.ts').StringId
+	readonly nameId: StringId
 	/** Type of this symbol */
 	readonly typeId: TypeId
 	/** WASM local index (fresh for each binding, supports shadowing) */
@@ -176,4 +177,58 @@ export interface SymbolEntry {
 export interface CheckResult {
 	/** Whether checking succeeded (no errors) */
 	readonly succeeded: boolean
+}
+
+// Inst accessor functions - type-safe access to instruction arguments
+
+export function getIntConstLow(inst: Inst): number {
+	return inst.arg0
+}
+
+export function getIntConstHigh(inst: Inst): number {
+	return inst.arg1
+}
+
+export function getFloatConstId(inst: Inst): FloatId {
+	return inst.arg0 as FloatId
+}
+
+export function getVarRefSymbolId(inst: Inst): SymbolId {
+	return inst.arg0 as SymbolId
+}
+
+export function getBindSymbolId(inst: Inst): SymbolId {
+	return inst.arg0 as SymbolId
+}
+
+export function getBindInitId(inst: Inst): InstId {
+	return inst.arg1 as InstId
+}
+
+export function getNegateOperandId(inst: Inst): InstId {
+	return inst.arg0 as InstId
+}
+
+export function getMatchScrutineeId(inst: Inst): InstId {
+	return inst.arg0 as InstId
+}
+
+export function getMatchArmCount(inst: Inst): number {
+	return inst.arg1
+}
+
+export function getMatchArmPatternNodeId(inst: Inst): NodeId {
+	return inst.arg0 as NodeId
+}
+
+export function getMatchArmBodyId(inst: Inst): InstId {
+	return inst.arg1 as InstId
+}
+
+export function getPatternBindSymbolId(inst: Inst): SymbolId {
+	return inst.arg0 as SymbolId
+}
+
+export function getPatternBindScrutineeId(inst: Inst): InstId {
+	return inst.arg1 as InstId
 }

--- a/packages/compiler/src/core/nodes.ts
+++ b/packages/compiler/src/core/nodes.ts
@@ -70,6 +70,14 @@ export function nodeId(n: number): NodeId {
 	return n as NodeId
 }
 
+export function prevNodeId(id: NodeId): NodeId {
+	return (id - 1) as NodeId
+}
+
+export function offsetNodeId(id: NodeId, offset: number): NodeId {
+	return (id + offset) as NodeId
+}
+
 /**
  * Range of node IDs for child access.
  */
@@ -135,7 +143,7 @@ export class NodeStore {
 		const childCount = node.subtreeSize - 1
 		return {
 			count: childCount,
-			start: (id - childCount) as NodeId,
+			start: offsetNodeId(id, -childCount),
 		}
 	}
 
@@ -150,15 +158,14 @@ export class NodeStore {
 		if (count === 0) return
 
 		// Start at the end of the child range
-		let pos = (start as number) + count - 1
+		let pos = offsetNodeId(start, count - 1)
 
-		while (pos >= (start as number)) {
-			const childId = pos as NodeId
-			const child = this.nodes[childId]
+		while (pos >= start) {
+			const child = this.nodes[pos]
 			if (child === undefined) break
-			yield [childId, child]
+			yield [pos, child]
 			// Move backwards past this child's subtree to find previous sibling
-			pos -= child.subtreeSize
+			pos = offsetNodeId(pos, -child.subtreeSize)
 		}
 	}
 
@@ -168,10 +175,10 @@ export class NodeStore {
 	 */
 	*iterateSubtree(id: NodeId): Generator<[NodeId, ParseNode]> {
 		const node = this.get(id)
-		const start = id - node.subtreeSize + 1
-		for (let i = start; i <= id; i++) {
+		const start = offsetNodeId(id, -node.subtreeSize + 1)
+		for (let i = start; i <= id; i = offsetNodeId(i, 1)) {
 			const n = this.nodes[i]
-			if (n !== undefined) yield [i as NodeId, n]
+			if (n !== undefined) yield [i, n]
 		}
 	}
 

--- a/packages/compiler/src/core/tokens.ts
+++ b/packages/compiler/src/core/tokens.ts
@@ -41,6 +41,14 @@ export function tokenId(n: number): TokenId {
 	return n as TokenId
 }
 
+export function nextTokenId(id: TokenId): TokenId {
+	return (id + 1) as TokenId
+}
+
+export function offsetTokenId(id: TokenId, offset: number): TokenId {
+	return (id + offset) as TokenId
+}
+
 /**
  * A single token - fixed size, no pointers.
  * Payload meaning depends on kind:

--- a/packages/compiler/src/parse/parser.ts
+++ b/packages/compiler/src/parse/parser.ts
@@ -1,8 +1,8 @@
 import type { Node } from 'ohm-js'
-import type { CompilationContext } from '../core/context.ts'
+import type { CompilationContext, StringId } from '../core/context.ts'
 import type { DiagnosticCode } from '../core/diagnostics.ts'
 import { type NodeId, NodeKind } from '../core/nodes.ts'
-import { type TokenId, TokenKind, tokenId } from '../core/tokens.ts'
+import { type Token, type TokenId, TokenKind, tokenId } from '../core/tokens.ts'
 import type { TinyWhaleSemantics } from './tinywhale.ohm-bundle.js'
 import TinyWhaleGrammar from './tinywhale.ohm-bundle.js'
 
@@ -11,10 +11,7 @@ export interface ParseResult {
 	rootNode?: NodeId
 }
 
-function tokenToOhmString(
-	token: import('../core/tokens.ts').Token,
-	context: CompilationContext
-): string | null {
+function tokenToOhmString(token: Token, context: CompilationContext): string | null {
 	switch (token.kind) {
 		case TokenKind.Indent:
 			return `⇥${token.payload}`
@@ -33,12 +30,12 @@ function tokenToOhmString(
 		case TokenKind.F64:
 			return 'f64'
 		case TokenKind.Identifier:
-			return context.strings.get(token.payload as import('../core/context.ts').StringId)
+			return context.strings.get(token.payload as StringId)
 		case TokenKind.IntLiteral:
 			// Now stored as StringId
-			return context.strings.get(token.payload as import('../core/context.ts').StringId)
+			return context.strings.get(token.payload as StringId)
 		case TokenKind.FloatLiteral:
-			return context.strings.get(token.payload as import('../core/context.ts').StringId)
+			return context.strings.get(token.payload as StringId)
 		case TokenKind.Colon:
 			return ':'
 		case TokenKind.Equals:
@@ -88,7 +85,7 @@ interface TokenMappingState {
 }
 
 function updateOhmPosition(
-	token: import('../core/tokens.ts').Token,
+	token: Token,
 	state: TokenMappingState,
 	ohmPositionToToken: Map<number, TokenId>,
 	id: TokenId,


### PR DESCRIPTION
- Add arithmetic helpers (prevNodeId, offsetNodeId, nextTokenId) to preserve branded types during navigation
- Add type-safe Inst accessor functions (getIntConstLow, getBindSymbolId, etc.) for accessing instruction fields
- Use branded StringId/InstId as Map keys instead of plain numbers
- Replace -1 sentinel with nullable InstId and add isValidExprResult type guard
- Replace inline import paths with proper type imports