### PR TITLE
feat: add arithmetic, bitwise, comparison, and logical operators

### DIFF
--- a/examples/arithmetic.tw
+++ b/examples/arithmetic.tw
@@ -1,0 +1,13 @@
+# Arithmetic operators
+a:i32 = 10 + 5    # addition: 15
+b:i32 = 10 - 3    # subtraction: 7
+c:i32 = 4 * 3     # multiplication: 12
+d:i32 = 20 / 4    # division: 5
+e:i32 = 10 % 3    # modulo: 1
+f:i32 = -7 %% 3   # euclidean modulo: 2
+
+# Float arithmetic
+g:f64 = 3.14 + 2.86  # 6.0
+h:f64 = 10.0 / 4.0   # 2.5
+
+panic

--- a/examples/bindings.tw
+++ b/examples/bindings.tw
@@ -1,4 +1,0 @@
-# Variable bindings with type annotations
-x:i32 = 42
-y:i64 = 100
-panic

--- a/examples/bitwise.tw
+++ b/examples/bitwise.tw
@@ -1,0 +1,17 @@
+# Bitwise operators
+a:i32 = 5 & 3     # AND: 1 (0101 & 0011 = 0001)
+b:i32 = 5 | 3     # OR:  7 (0101 | 0011 = 0111)
+c:i32 = 5 ^ 3     # XOR: 6 (0101 ^ 0011 = 0110)
+d:i32 = ~5        # NOT: -6
+
+# Shift operators
+e:i32 = 1 << 4    # left shift: 16
+f:i32 = 16 >> 2   # signed right shift: 4
+g:i32 = 16 >>> 2  # unsigned right shift: 4
+
+# i64 bitwise
+h:i64 = 255
+j:i64 = 15
+i:i64 = h & j    # 15
+
+panic

--- a/examples/comparison.tw
+++ b/examples/comparison.tw
@@ -1,0 +1,17 @@
+# Comparison operators (result is always i32: 0 or 1)
+a:i32 = 1 < 2     # less than: 1
+b:i32 = 2 > 1     # greater than: 1
+c:i32 = 1 <= 1    # less equal: 1
+d:i32 = 2 >= 2    # greater equal: 1
+e:i32 = 1 == 1    # equal: 1
+f:i32 = 1 != 2    # not equal: 1
+
+# Float comparison
+g:f64 = 1.5
+h:f64 = 2.5
+i:i32 = g < h     # 1
+
+# Comparison chaining
+j:i32 = 1 < 2 < 3   # (1 < 2) && (2 < 3): 1
+
+panic

--- a/examples/floats.tw
+++ b/examples/floats.tw
@@ -1,4 +1,0 @@
-# Variable bindings with type annotations
-x: f32 = 0.1
-y: f64 = -0.2
-panic

--- a/examples/logical.tw
+++ b/examples/logical.tw
@@ -1,0 +1,11 @@
+# Logical operators (short-circuit evaluation)
+a:i32 = 1 && 2    # logical AND: 2 (truthy, returns right)
+b:i32 = 0 && 2    # logical AND: 0 (falsy, returns left)
+c:i32 = 0 || 1    # logical OR: 1 (first truthy)
+d:i32 = 0 || 0    # logical OR: 0 (both falsy)
+
+# Combined with comparison
+e:i32 = (1 < 2) && (3 < 4)   # 1
+f:i32 = (1 > 2) || (3 < 4)   # 1
+
+panic

--- a/examples/precedence.tw
+++ b/examples/precedence.tw
@@ -1,0 +1,19 @@
+# Operator precedence demonstration
+# Higher precedence binds tighter
+
+# Multiplication before addition
+a:i32 = 1 + 2 * 3        # 7, not 9
+
+# Parentheses override precedence
+b:i32 = (1 + 2) * 3      # 9
+
+# Complex expression
+c:i32 = 1 + 2 * 3 + 4    # 11
+
+# Nested parentheses
+d:i32 = ((1 + 2) * (3 + 4))  # 21
+
+# Comparison before logical
+e:i32 = 1 < 2 && 3 < 4   # 1
+
+panic

--- a/examples/references.tw
+++ b/examples/references.tw
@@ -1,5 +1,0 @@
-# Variables can reference previously defined variables
-a:i32 = 10
-b:i32 = a      # b gets value of a
-c:i32 = b      # c gets value of b
-panic

--- a/packages/compiler/src/check/types.ts
+++ b/packages/compiler/src/check/types.ts
@@ -42,12 +42,20 @@ export function symbolId(n: number): SymbolId {
  * - Control flow: 40-49
  */
 export const InstKind = {
+	/** Binary operation: arg0 = left InstId, arg1 = right InstId. Operator from parseNodeId. */
+	BinaryOp: 32,
 	/** Variable binding: arg0 = SymbolId, arg1 = initializer InstId */
 	Bind: 20,
+	/** Bitwise NOT: arg0 = operand InstId */
+	BitwiseNot: 31,
 	/** Float constant: arg0 = FloatId (index into FloatStore) */
 	FloatConst: 11,
 	/** Integer constant: arg0 = low 32 bits, arg1 = high 32 bits (for i64) */
 	IntConst: 10,
+	/** Logical AND (short-circuit): arg0 = left InstId, arg1 = right InstId */
+	LogicalAnd: 33,
+	/** Logical OR (short-circuit): arg0 = left InstId, arg1 = right InstId */
+	LogicalOr: 34,
 	/** Match expression: arg0 = scrutinee InstId, arg1 = arm count */
 	Match: 40,
 	/** Match arm: arg0 = pattern InstId, arg1 = body InstId */
@@ -230,5 +238,33 @@ export function getPatternBindSymbolId(inst: Inst): SymbolId {
 }
 
 export function getPatternBindScrutineeId(inst: Inst): InstId {
+	return inst.arg1 as InstId
+}
+
+export function getBinaryOpLeftId(inst: Inst): InstId {
+	return inst.arg0 as InstId
+}
+
+export function getBinaryOpRightId(inst: Inst): InstId {
+	return inst.arg1 as InstId
+}
+
+export function getBitwiseNotOperandId(inst: Inst): InstId {
+	return inst.arg0 as InstId
+}
+
+export function getLogicalAndLeftId(inst: Inst): InstId {
+	return inst.arg0 as InstId
+}
+
+export function getLogicalAndRightId(inst: Inst): InstId {
+	return inst.arg1 as InstId
+}
+
+export function getLogicalOrLeftId(inst: Inst): InstId {
+	return inst.arg0 as InstId
+}
+
+export function getLogicalOrRightId(inst: Inst): InstId {
 	return inst.arg1 as InstId
 }

--- a/packages/compiler/src/core/nodes.ts
+++ b/packages/compiler/src/core/nodes.ts
@@ -8,7 +8,9 @@ import type { TokenId } from './tokens.ts'
 
 /** Node kinds - one per grammar production. */
 export const NodeKind = {
+	BinaryExpr: 104,
 	BindingPattern: 202,
+	CompareChain: 106,
 	DedentLine: 1,
 	FloatLiteral: 103,
 
@@ -24,6 +26,7 @@ export const NodeKind = {
 
 	// Statements (10-99)
 	PanicStatement: 10,
+	ParenExpr: 105,
 
 	// Program root (255)
 	Program: 255,

--- a/packages/compiler/src/core/tokens.ts
+++ b/packages/compiler/src/core/tokens.ts
@@ -5,16 +5,26 @@
 
 /** Token kinds - small integer discriminant. */
 export const TokenKind = {
+	Ampersand: 24,
+	AmpersandAmpersand: 38,
 	Arrow: 6,
+	Bang: 29,
+	BangEqual: 37,
+	Caret: 25,
 	Colon: 3,
 	Dedent: 1,
 
 	// Special (255)
 	Eof: 255,
+	EqualEqual: 36,
 	Equals: 4,
 	F32: 13,
 	F64: 14,
 	FloatLiteral: 102,
+	GreaterEqual: 35,
+	GreaterGreater: 32,
+	GreaterGreaterGreater: 33,
+	GreaterThan: 28,
 	I32: 11,
 	I64: 12,
 
@@ -23,13 +33,29 @@ export const TokenKind = {
 	// Structural tokens (0-9)
 	Indent: 0,
 	IntLiteral: 101,
+	LessEqual: 34,
+	LessLess: 31,
+	LessThan: 27,
+	LParen: 40,
 	Match: 15,
 	Minus: 5,
 	Newline: 2,
 
-	// Keywords (10-99)
+	// Keywords (10-19)
 	Panic: 10,
+	Percent: 23,
+
+	// Multi-char operators (30-49)
+	PercentPercent: 30,
 	Pipe: 8,
+	PipePipe: 39,
+
+	// Single-char operators (20-29)
+	Plus: 20,
+	RParen: 41,
+	Slash: 22,
+	Star: 21,
+	Tilde: 26,
 	Underscore: 7,
 } as const
 

--- a/packages/compiler/src/parse/tinywhale.ohm
+++ b/packages/compiler/src/parse/tinywhale.ohm
@@ -33,10 +33,31 @@ TinyWhale {
   LiteralPattern = minus? intLiteral
   BindingPattern = ~keyword ~underscore identifier
 
-  // Expressions
-  Expression = UnaryExpr | identifier | floatLiteral | intLiteral
-  UnaryExpr = minus PrimaryExpr
-  PrimaryExpr = identifier | floatLiteral | intLiteral
+  // Expressions (precedence from lowest to highest)
+  Expression = LogicalOrExpr
+
+  LogicalOrExpr = LogicalAndExpr (pipePipe LogicalAndExpr)*
+  LogicalAndExpr = BitwiseOrExpr (ampAmp BitwiseOrExpr)*
+  BitwiseOrExpr = BitwiseXorExpr (bitwiseOr BitwiseXorExpr)*
+  BitwiseXorExpr = BitwiseAndExpr (caret BitwiseAndExpr)*
+  BitwiseAndExpr = CompareExpr (ampersand CompareExpr)*
+  CompareExpr = AddExpr (compareOp AddExpr)*
+  AddExpr = MulExpr (addOp MulExpr)*
+  MulExpr = UnaryExpr (mulOp UnaryExpr)*
+
+  UnaryExpr = unaryOp UnaryExpr  -- unary
+            | PrimaryExpr        -- primary
+
+  PrimaryExpr = lparen Expression rparen  -- paren
+              | identifier
+              | floatLiteral
+              | intLiteral
+
+  // Operator groups
+  compareOp = lessEqual | greaterEqual | lessThan | greaterThan | equalEqual | bangEqual
+  addOp = plus | minus
+  mulOp = star | slash | percentPercent | percent | greaterGreaterGreater | greaterGreater | lessLess
+  unaryOp = minus | tilde
 
   // Keywords
   keyword = panic | typeKeyword | matchKeyword
@@ -59,6 +80,40 @@ TinyWhale {
   arrow = "->"
   underscore = "_" ~identifierPart
   pipe = "|"
+
+  // Arithmetic operators
+  plus = "+"
+  star = "*"
+  slash = "/"
+  percent = "%"
+  percentPercent = "%%"
+  tilde = "~"
+
+  // Comparison operators (order matters: longer first)
+  lessEqual = "<="
+  greaterEqual = ">="
+  lessThan = "<"
+  greaterThan = ">"
+  equalEqual = "=="
+  bangEqual = "!="
+
+  // Shift operators (order matters: longer first)
+  greaterGreaterGreater = ">>>"
+  greaterGreater = ">>"
+  lessLess = "<<"
+
+  // Bitwise operators
+  ampersand = "&"
+  caret = "^"
+  bitwiseOr = "|" ~"|"
+
+  // Logical operators
+  ampAmp = "&&"
+  pipePipe = "||"
+
+  // Grouping
+  lparen = "("
+  rparen = ")"
 
   // Lexical token rules (marker followed by indent level)
   indentToken = "⇥" digit+

--- a/packages/compiler/test/check/binary-expr.test.ts
+++ b/packages/compiler/test/check/binary-expr.test.ts
@@ -1,0 +1,267 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+
+import { check } from '../../src/check/checker.ts'
+import { InstKind } from '../../src/check/types.ts'
+import { CompilationContext } from '../../src/core/context.ts'
+import { compile } from '../../src/index.ts'
+import { tokenize } from '../../src/lex/tokenizer.ts'
+import { parse } from '../../src/parse/parser.ts'
+
+function compileAndCheck(source: string): CompilationContext {
+	const ctx = new CompilationContext(source)
+	tokenize(ctx)
+	parse(ctx)
+	check(ctx)
+	return ctx
+}
+
+describe('check/binary expressions', () => {
+	describe('arithmetic operators', () => {
+		it('should compile i32 addition', () => {
+			const ctx = compileAndCheck('x:i32 = 1 + 2\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should compile i32 subtraction', () => {
+			const ctx = compileAndCheck('x:i32 = 5 - 3\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should compile i32 multiplication', () => {
+			const ctx = compileAndCheck('x:i32 = 3 * 4\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should compile i32 division', () => {
+			const ctx = compileAndCheck('x:i32 = 10 / 2\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should compile i32 modulo', () => {
+			const ctx = compileAndCheck('x:i32 = 10 % 3\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should compile i32 euclidean modulo', () => {
+			const ctx = compileAndCheck('x:i32 = 10 %% 3\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should compile i64 arithmetic', () => {
+			const ctx = compileAndCheck('a:i64 = 100\nb:i64 = 50\nx:i64 = a + b\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should compile f32 arithmetic', () => {
+			const ctx = compileAndCheck('a:f32 = 1.5\nb:f32 = 2.5\nx:f32 = a + b\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should compile f64 arithmetic', () => {
+			const ctx = compileAndCheck('a:f64 = 1.5\nb:f64 = 2.5\nx:f64 = a * b\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should emit BinaryOp instruction', () => {
+			const ctx = compileAndCheck('x:i32 = 1 + 2\n')
+			assert.ok(ctx.insts)
+			let hasBinaryOp = false
+			for (const [, inst] of ctx.insts) {
+				if (inst.kind === InstKind.BinaryOp) hasBinaryOp = true
+			}
+			assert.ok(hasBinaryOp)
+		})
+
+		it('should error on modulo with float operand', () => {
+			const ctx = compileAndCheck('a:f32 = 1.0\nb:f32 = 2.0\nx:f32 = a % b\n')
+			assert.strictEqual(ctx.hasErrors(), true)
+			const errors = ctx.getErrors()
+			assert.ok(errors.some((e) => e.message.includes('integer')))
+		})
+
+		it('should error on euclidean modulo with float operand', () => {
+			const ctx = compileAndCheck('a:f64 = 1.0\nb:f64 = 2.0\nx:f64 = a %% b\n')
+			assert.strictEqual(ctx.hasErrors(), true)
+		})
+	})
+
+	describe('bitwise operators', () => {
+		it('should compile bitwise AND', () => {
+			const ctx = compileAndCheck('x:i32 = 5 & 3\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should compile bitwise OR', () => {
+			const ctx = compileAndCheck('x:i32 = 5 | 3\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should compile bitwise XOR', () => {
+			const ctx = compileAndCheck('x:i32 = 5 ^ 3\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should compile bitwise NOT', () => {
+			const ctx = compileAndCheck('x:i32 = ~5\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should compile left shift', () => {
+			const ctx = compileAndCheck('x:i32 = 1 << 4\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should compile right shift', () => {
+			const ctx = compileAndCheck('x:i32 = 16 >> 2\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should compile unsigned right shift', () => {
+			const ctx = compileAndCheck('x:i32 = 16 >>> 2\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should emit BitwiseNot instruction', () => {
+			const ctx = compileAndCheck('x:i32 = ~5\n')
+			assert.ok(ctx.insts)
+			let hasBitwiseNot = false
+			for (const [, inst] of ctx.insts) {
+				if (inst.kind === InstKind.BitwiseNot) hasBitwiseNot = true
+			}
+			assert.ok(hasBitwiseNot)
+		})
+
+		it('should compile i64 bitwise operations', () => {
+			const ctx = compileAndCheck('a:i64 = 100\nb:i64 = 50\nx:i64 = a & b\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should error on bitwise AND with float operand', () => {
+			const ctx = compileAndCheck('a:f32 = 1.0\nb:f32 = 2.0\nx:f32 = a & b\n')
+			assert.strictEqual(ctx.hasErrors(), true)
+		})
+
+		it('should error on bitwise OR with float operand', () => {
+			const ctx = compileAndCheck('a:f64 = 1.0\nb:f64 = 2.0\nx:f64 = a | b\n')
+			assert.strictEqual(ctx.hasErrors(), true)
+		})
+
+		it('should error on bitwise NOT with float operand', () => {
+			const ctx = compileAndCheck('a:f32 = 1.0\nx:f32 = ~a\n')
+			assert.strictEqual(ctx.hasErrors(), true)
+		})
+
+		it('should error on shift with float operand', () => {
+			const ctx = compileAndCheck('a:f32 = 1.0\nx:f32 = a << 2\n')
+			assert.strictEqual(ctx.hasErrors(), true)
+		})
+	})
+
+	describe('comparison operators', () => {
+		it('should compile less than', () => {
+			const ctx = compileAndCheck('x:i32 = 1 < 2\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should compile greater than', () => {
+			const ctx = compileAndCheck('x:i32 = 2 > 1\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should compile less equal', () => {
+			const ctx = compileAndCheck('x:i32 = 1 <= 2\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should compile greater equal', () => {
+			const ctx = compileAndCheck('x:i32 = 2 >= 1\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should compile equal equal', () => {
+			const ctx = compileAndCheck('x:i32 = 1 == 1\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should compile not equal', () => {
+			const ctx = compileAndCheck('x:i32 = 1 != 2\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should compile float comparison', () => {
+			const ctx = compileAndCheck('a:f64 = 1.5\nb:f64 = 2.5\nx:i32 = a < b\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should compile comparison chain', () => {
+			const ctx = compileAndCheck('x:i32 = 1 < 2 < 3\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+	})
+
+	describe('logical operators', () => {
+		it('should compile logical AND', () => {
+			const ctx = compileAndCheck('x:i32 = 1 && 2\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should compile logical OR', () => {
+			const ctx = compileAndCheck('x:i32 = 0 || 1\n')
+			assert.strictEqual(ctx.hasErrors(), false)
+		})
+
+		it('should emit LogicalAnd instruction', () => {
+			const ctx = compileAndCheck('x:i32 = 1 && 2\n')
+			assert.ok(ctx.insts)
+			let hasLogicalAnd = false
+			for (const [, inst] of ctx.insts) {
+				if (inst.kind === InstKind.LogicalAnd) hasLogicalAnd = true
+			}
+			assert.ok(hasLogicalAnd)
+		})
+
+		it('should emit LogicalOr instruction', () => {
+			const ctx = compileAndCheck('x:i32 = 0 || 1\n')
+			assert.ok(ctx.insts)
+			let hasLogicalOr = false
+			for (const [, inst] of ctx.insts) {
+				if (inst.kind === InstKind.LogicalOr) hasLogicalOr = true
+			}
+			assert.ok(hasLogicalOr)
+		})
+	})
+
+	describe('type checking', () => {
+		it('should error on type mismatch in binary expression', () => {
+			const ctx = compileAndCheck('a:i32 = 1\nb:i64 = 2\nx:i32 = a + b\n')
+			assert.strictEqual(ctx.hasErrors(), true)
+			const errors = ctx.getErrors()
+			assert.ok(errors.some((e) => e.message.includes('type mismatch')))
+		})
+
+		it('should error on assigning wrong result type', () => {
+			const ctx = compileAndCheck('a:i32 = 1\nb:i32 = 2\nx:i64 = a + b\n')
+			assert.strictEqual(ctx.hasErrors(), true)
+		})
+	})
+
+	describe('precedence and associativity', () => {
+		it('should respect multiplication over addition', () => {
+			const result = compile('x:i32 = 1 + 2 * 3\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i32.mul'))
+			assert.ok(result.text.includes('i32.add'))
+		})
+
+		it('should respect parentheses', () => {
+			const result = compile('x:i32 = (1 + 2) * 3\npanic\n')
+			assert.strictEqual(result.valid, true)
+		})
+
+		it('should be left-associative for subtraction', () => {
+			const result = compile('x:i32 = 10 - 3 - 2\npanic\n')
+			assert.strictEqual(result.valid, true)
+		})
+	})
+})

--- a/packages/compiler/test/codegen.test.ts
+++ b/packages/compiler/test/codegen.test.ts
@@ -156,4 +156,211 @@ describe('codegen', () => {
 			assert.ok(error instanceof Error)
 		})
 	})
+
+	describe('arithmetic operators', () => {
+		it('should emit i32.add for addition', () => {
+			const result = compileSource('x:i32 = 1 + 2\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i32.add'))
+		})
+
+		it('should emit i32.sub for subtraction', () => {
+			const result = compileSource('x:i32 = 5 - 3\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i32.sub'))
+		})
+
+		it('should emit i32.mul for multiplication', () => {
+			const result = compileSource('x:i32 = 3 * 4\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i32.mul'))
+		})
+
+		it('should emit i32.div_s for division', () => {
+			const result = compileSource('x:i32 = 10 / 2\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i32.div_s'))
+		})
+
+		it('should emit i32.rem_s for modulo', () => {
+			const result = compileSource('x:i32 = 10 % 3\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i32.rem_s'))
+		})
+
+		it('should emit i64.add for i64 addition', () => {
+			const result = compileSource('a:i64 = 100\nb:i64 = 50\nx:i64 = a + b\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i64.add'))
+		})
+
+		it('should emit f32.add for f32 addition', () => {
+			const result = compileSource('a:f32 = 1.5\nb:f32 = 2.5\nx:f32 = a + b\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('f32.add'))
+		})
+
+		it('should emit f64.mul for f64 multiplication', () => {
+			const result = compileSource('a:f64 = 1.5\nb:f64 = 2.5\nx:f64 = a * b\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('f64.mul'))
+		})
+
+		it('should emit f64.div for f64 division', () => {
+			const result = compileSource('a:f64 = 10.0\nb:f64 = 2.0\nx:f64 = a / b\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('f64.div'))
+		})
+	})
+
+	describe('bitwise operators', () => {
+		it('should emit i32.and for bitwise AND', () => {
+			const result = compileSource('x:i32 = 5 & 3\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i32.and'))
+		})
+
+		it('should emit i32.or for bitwise OR', () => {
+			const result = compileSource('x:i32 = 5 | 3\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i32.or'))
+		})
+
+		it('should emit i32.xor for bitwise XOR', () => {
+			const result = compileSource('x:i32 = 5 ^ 3\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i32.xor'))
+		})
+
+		it('should emit i32.xor with -1 for bitwise NOT', () => {
+			const result = compileSource('x:i32 = ~5\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i32.xor'))
+		})
+
+		it('should emit i32.shl for left shift', () => {
+			const result = compileSource('x:i32 = 1 << 4\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i32.shl'))
+		})
+
+		it('should emit i32.shr_s for signed right shift', () => {
+			const result = compileSource('x:i32 = 16 >> 2\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i32.shr_s'))
+		})
+
+		it('should emit i32.shr_u for unsigned right shift', () => {
+			const result = compileSource('x:i32 = 16 >>> 2\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i32.shr_u'))
+		})
+
+		it('should emit i64.and for i64 bitwise AND', () => {
+			const result = compileSource('a:i64 = 100\nb:i64 = 50\nx:i64 = a & b\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i64.and'))
+		})
+
+		it('should emit i64.xor with -1 for i64 bitwise NOT', () => {
+			const result = compileSource('a:i64 = 100\nx:i64 = ~a\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i64.xor'))
+		})
+	})
+
+	describe('comparison operators', () => {
+		it('should emit i32.lt_s for less than', () => {
+			const result = compileSource('x:i32 = 1 < 2\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i32.lt_s'))
+		})
+
+		it('should emit i32.gt_s for greater than', () => {
+			const result = compileSource('x:i32 = 2 > 1\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i32.gt_s'))
+		})
+
+		it('should emit i32.le_s for less equal', () => {
+			const result = compileSource('x:i32 = 1 <= 2\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i32.le_s'))
+		})
+
+		it('should emit i32.ge_s for greater equal', () => {
+			const result = compileSource('x:i32 = 2 >= 1\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i32.ge_s'))
+		})
+
+		it('should emit i32.eq for equal equal', () => {
+			const result = compileSource('x:i32 = 1 == 1\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i32.eq'))
+		})
+
+		it('should emit i32.ne for not equal', () => {
+			const result = compileSource('x:i32 = 1 != 2\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i32.ne'))
+		})
+
+		it('should emit f64.lt for float less than', () => {
+			const result = compileSource('a:f64 = 1.5\nb:f64 = 2.5\nx:i32 = a < b\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('f64.lt'))
+		})
+
+		it('should emit f32.eq for float equal', () => {
+			const result = compileSource('a:f32 = 1.5\nb:f32 = 1.5\nx:i32 = a == b\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('f32.eq'))
+		})
+	})
+
+	describe('logical operators', () => {
+		it('should emit if for logical AND (short-circuit)', () => {
+			const result = compileSource('x:i32 = 1 && 2\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('if'))
+		})
+
+		it('should emit if for logical OR (short-circuit)', () => {
+			const result = compileSource('x:i32 = 0 || 1\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('if'))
+		})
+	})
+
+	describe('complex expressions', () => {
+		it('should compile chained arithmetic', () => {
+			const result = compileSource('x:i32 = 1 + 2 + 3 + 4\npanic\n')
+			assert.strictEqual(result.valid, true)
+			const addCount = (result.text.match(/i32\.add/g) || []).length
+			assert.strictEqual(addCount, 3)
+		})
+
+		it('should compile mixed operators with precedence', () => {
+			const result = compileSource('x:i32 = 1 + 2 * 3\npanic\n')
+			assert.strictEqual(result.valid, true)
+			assert.ok(result.text.includes('i32.mul'))
+			assert.ok(result.text.includes('i32.add'))
+		})
+
+		it('should compile parenthesized expressions', () => {
+			const result = compileSource('x:i32 = (1 + 2) * 3\npanic\n')
+			assert.strictEqual(result.valid, true)
+		})
+
+		it('should compile comparison chain', () => {
+			const result = compileSource('x:i32 = 1 < 2 < 3\npanic\n')
+			assert.strictEqual(result.valid, true)
+		})
+
+		it('should compile nested parentheses', () => {
+			const result = compileSource('x:i32 = ((1 + 2) * (3 + 4))\npanic\n')
+			assert.strictEqual(result.valid, true)
+		})
+	})
 })

--- a/packages/compiler/test/lex/tokenizer.test.ts
+++ b/packages/compiler/test/lex/tokenizer.test.ts
@@ -4,6 +4,14 @@ import { CompilationContext } from '../../src/core/context.ts'
 import { TokenKind } from '../../src/core/tokens.ts'
 import { tokenize } from '../../src/lex/tokenizer.ts'
 
+function getTokenKinds(ctx: CompilationContext): TokenKind[] {
+	const kinds: TokenKind[] = []
+	for (const [, token] of ctx.tokens) {
+		kinds.push(token.kind)
+	}
+	return kinds
+}
+
 describe('lex/tokenizer', () => {
 	describe('basic tokenization', () => {
 		it('should tokenize empty input', () => {
@@ -256,6 +264,196 @@ describe('lex/tokenizer', () => {
 				}
 			}
 			assert.deepStrictEqual(panicTokens, [1, 3])
+		})
+	})
+
+	describe('arithmetic operators', () => {
+		it('should tokenize plus', () => {
+			const ctx = new CompilationContext('x:i32 = 1 + 2')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.Plus))
+		})
+
+		it('should tokenize minus', () => {
+			const ctx = new CompilationContext('x:i32 = 1 - 2')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.Minus))
+		})
+
+		it('should tokenize star', () => {
+			const ctx = new CompilationContext('x:i32 = 1 * 2')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.Star))
+		})
+
+		it('should tokenize slash', () => {
+			const ctx = new CompilationContext('x:i32 = 1 / 2')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.Slash))
+		})
+
+		it('should tokenize percent', () => {
+			const ctx = new CompilationContext('x:i32 = 5 % 3')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.Percent))
+		})
+
+		it('should tokenize percent percent', () => {
+			const ctx = new CompilationContext('x:i32 = 5 %% 3')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.PercentPercent))
+		})
+	})
+
+	describe('bitwise operators', () => {
+		it('should tokenize ampersand', () => {
+			const ctx = new CompilationContext('x:i32 = 1 & 2')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.Ampersand))
+		})
+
+		it('should tokenize pipe', () => {
+			const ctx = new CompilationContext('x:i32 = 1 | 2')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.Pipe))
+		})
+
+		it('should tokenize caret', () => {
+			const ctx = new CompilationContext('x:i32 = 1 ^ 2')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.Caret))
+		})
+
+		it('should tokenize tilde', () => {
+			const ctx = new CompilationContext('x:i32 = ~1')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.Tilde))
+		})
+
+		it('should tokenize less less (left shift)', () => {
+			const ctx = new CompilationContext('x:i32 = 1 << 2')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.LessLess))
+		})
+
+		it('should tokenize greater greater (right shift)', () => {
+			const ctx = new CompilationContext('x:i32 = 4 >> 1')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.GreaterGreater))
+		})
+
+		it('should tokenize greater greater greater (unsigned right shift)', () => {
+			const ctx = new CompilationContext('x:i32 = 4 >>> 1')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.GreaterGreaterGreater))
+		})
+
+		it('should not confuse >> with >>>', () => {
+			const ctx = new CompilationContext('x:i32 = 4 >> 1')
+			tokenize(ctx)
+			const kinds = getTokenKinds(ctx)
+			assert.ok(kinds.includes(TokenKind.GreaterGreater))
+			assert.ok(!kinds.includes(TokenKind.GreaterGreaterGreater))
+		})
+	})
+
+	describe('comparison operators', () => {
+		it('should tokenize less than', () => {
+			const ctx = new CompilationContext('x:i32 = 1 < 2')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.LessThan))
+		})
+
+		it('should tokenize greater than', () => {
+			const ctx = new CompilationContext('x:i32 = 2 > 1')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.GreaterThan))
+		})
+
+		it('should tokenize less equal', () => {
+			const ctx = new CompilationContext('x:i32 = 1 <= 2')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.LessEqual))
+		})
+
+		it('should tokenize greater equal', () => {
+			const ctx = new CompilationContext('x:i32 = 2 >= 1')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.GreaterEqual))
+		})
+
+		it('should tokenize equal equal', () => {
+			const ctx = new CompilationContext('x:i32 = 1 == 1')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.EqualEqual))
+		})
+
+		it('should tokenize bang equal', () => {
+			const ctx = new CompilationContext('x:i32 = 1 != 2')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.BangEqual))
+		})
+
+		it('should not confuse = with ==', () => {
+			const ctx = new CompilationContext('x:i32 = 1 == 2')
+			tokenize(ctx)
+			const kinds = getTokenKinds(ctx)
+			assert.ok(kinds.includes(TokenKind.Equals))
+			assert.ok(kinds.includes(TokenKind.EqualEqual))
+		})
+	})
+
+	describe('logical operators', () => {
+		it('should tokenize ampersand ampersand', () => {
+			const ctx = new CompilationContext('x:i32 = 1 && 2')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.AmpersandAmpersand))
+		})
+
+		it('should tokenize pipe pipe', () => {
+			const ctx = new CompilationContext('x:i32 = 1 || 2')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.PipePipe))
+		})
+
+		it('should not confuse & with &&', () => {
+			const ctx = new CompilationContext('x:i32 = 1 & 2')
+			tokenize(ctx)
+			const kinds = getTokenKinds(ctx)
+			assert.ok(kinds.includes(TokenKind.Ampersand))
+			assert.ok(!kinds.includes(TokenKind.AmpersandAmpersand))
+		})
+
+		it('should not confuse | with ||', () => {
+			const ctx = new CompilationContext('x:i32 = 1 | 2')
+			tokenize(ctx)
+			const kinds = getTokenKinds(ctx)
+			assert.ok(kinds.includes(TokenKind.Pipe))
+			assert.ok(!kinds.includes(TokenKind.PipePipe))
+		})
+	})
+
+	describe('parentheses', () => {
+		it('should tokenize left paren', () => {
+			const ctx = new CompilationContext('x:i32 = (1)')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.LParen))
+		})
+
+		it('should tokenize right paren', () => {
+			const ctx = new CompilationContext('x:i32 = (1)')
+			tokenize(ctx)
+			assert.ok(getTokenKinds(ctx).includes(TokenKind.RParen))
+		})
+
+		it('should tokenize nested parentheses', () => {
+			const ctx = new CompilationContext('x:i32 = ((1 + 2) * 3)')
+			tokenize(ctx)
+			const kinds = getTokenKinds(ctx)
+			const lparenCount = kinds.filter((k) => k === TokenKind.LParen).length
+			const rparenCount = kinds.filter((k) => k === TokenKind.RParen).length
+			assert.strictEqual(lparenCount, 2)
+			assert.strictEqual(rparenCount, 2)
 		})
 	})
 })

--- a/packages/diagnostics/src/compiler.ts
+++ b/packages/diagnostics/src/compiler.ts
@@ -164,6 +164,47 @@ export const TWCHECK020: DiagnosticDef = {
 	suggestion: 'Add a wildcard pattern `_` or binding pattern as the last arm.',
 }
 
+export const TWCHECK021: DiagnosticDef = {
+	code: 'TWCHECK021',
+	description:
+		'This operator only works with integer types (i32, i64), but got a floating-point type.',
+	message: 'integer-only operator `{op}` used with `{type}`',
+	severity: DiagnosticSeverity.Error,
+	suggestion: 'Use an integer type or a different operator.',
+}
+
+export const TWCHECK022: DiagnosticDef = {
+	code: 'TWCHECK022',
+	description: 'Binary operators require both operands to have the same type.',
+	message: 'operand type mismatch: `{left}` vs `{right}`',
+	severity: DiagnosticSeverity.Error,
+	suggestion: 'Ensure both operands have the same type.',
+}
+
+export const TWCHECK023: DiagnosticDef = {
+	code: 'TWCHECK023',
+	description: 'Adjacent != operators in a comparison chain are ambiguous.',
+	message: 'adjacent != operators in comparison chain',
+	severity: DiagnosticSeverity.Error,
+	suggestion: 'Break this into separate comparisons joined with &&.',
+}
+
+export const TWCHECK024: DiagnosticDef = {
+	code: 'TWCHECK024',
+	description: 'Logical operators require integer operands (i32 or i64).',
+	message: 'logical operator `{op}` used with `{type}`',
+	severity: DiagnosticSeverity.Error,
+	suggestion: 'Convert to an integer type before using logical operators.',
+}
+
+export const TWCHECK025: DiagnosticDef = {
+	code: 'TWCHECK025',
+	description: 'Division by zero is undefined behavior.',
+	message: 'division by zero',
+	severity: DiagnosticSeverity.Error,
+	suggestion: 'Use a non-zero divisor.',
+}
+
 // =============================================================================
 // CHECKER WARNINGS (TWCHECK050-099)
 // =============================================================================
@@ -205,6 +246,11 @@ export const COMPILER_DIAGNOSTICS = {
 	TWCHECK018,
 	TWCHECK019,
 	TWCHECK020,
+	TWCHECK021,
+	TWCHECK022,
+	TWCHECK023,
+	TWCHECK024,
+	TWCHECK025,
 	TWCHECK050,
 	TWGEN001,
 	TWLEX001,


### PR DESCRIPTION
Implement full expression support with operator precedence:
- Arithmetic: + - * / % %% (euclidean mod)
- Bitwise: & | ^ ~ << >> >>>
- Comparison: < <= > >= == != (with chaining support)
- Logical: && || (short-circuit evaluation)

Includes tokenizer, parser, checker, and codegen for all operators. Adds comprehensive tests and replaces obsolete examples.