### PR TITLE
test: add parser edge cases and tokenizer property tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "2.3.11",
 		"@types/node": "25.0.6",
+		"fast-check": "4.5.3",
 		"typescript": "5.9.3"
 	},
 	"engines": {

--- a/packages/compiler/test/lex/tokenizer.property.test.ts
+++ b/packages/compiler/test/lex/tokenizer.property.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test'
 import fc from 'fast-check'
 import { CompilationContext } from '../../src/core/context.ts'
+import { TokenKind } from '../../src/core/tokens.ts'
 import { tokenize } from '../../src/lex/tokenizer.ts'
 
 describe('lex/tokenizer properties', () => {
@@ -22,6 +23,19 @@ describe('lex/tokenizer properties', () => {
 					const ctx = new CompilationContext(input)
 					tokenize(ctx)
 					return ctx.tokens.count() >= 1
+				}),
+				{ numRuns: 1000 }
+			)
+		})
+
+		it('final token is always EOF', () => {
+			fc.assert(
+				fc.property(fc.string(), (input) => {
+					const ctx = new CompilationContext(input)
+					tokenize(ctx)
+					const lastIndex = ctx.tokens.count() - 1
+					const lastToken = ctx.tokens.get(lastIndex as never)
+					return lastToken.kind === TokenKind.Eof
 				}),
 				{ numRuns: 1000 }
 			)

--- a/packages/compiler/test/lex/tokenizer.property.test.ts
+++ b/packages/compiler/test/lex/tokenizer.property.test.ts
@@ -66,4 +66,22 @@ describe('lex/tokenizer properties', () => {
 			)
 		})
 	})
+
+	describe('structural properties', () => {
+		it('every token has valid line and column (>= 1)', () => {
+			fc.assert(
+				fc.property(fc.string(), (input) => {
+					const ctx = new CompilationContext(input)
+					tokenize(ctx)
+					for (const [, token] of ctx.tokens) {
+						if (token.line < 1 || token.column < 1) {
+							return false
+						}
+					}
+					return true
+				}),
+				{ numRuns: 1000 }
+			)
+		})
+	})
 })

--- a/packages/compiler/test/lex/tokenizer.property.test.ts
+++ b/packages/compiler/test/lex/tokenizer.property.test.ts
@@ -84,4 +84,23 @@ describe('lex/tokenizer properties', () => {
 			)
 		})
 	})
+
+	describe('indentation properties', () => {
+		it('INDENT count equals DEDENT count (balanced)', () => {
+			fc.assert(
+				fc.property(fc.string(), (input) => {
+					const ctx = new CompilationContext(input)
+					tokenize(ctx)
+					let indentCount = 0
+					let dedentCount = 0
+					for (const [, token] of ctx.tokens) {
+						if (token.kind === TokenKind.Indent) indentCount++
+						if (token.kind === TokenKind.Dedent) dedentCount++
+					}
+					return indentCount === dedentCount
+				}),
+				{ numRuns: 1000 }
+			)
+		})
+	})
 })

--- a/packages/compiler/test/lex/tokenizer.property.test.ts
+++ b/packages/compiler/test/lex/tokenizer.property.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import fc from 'fast-check'
+import { CompilationContext } from '../../src/core/context.ts'
+import { tokenize } from '../../src/lex/tokenizer.ts'
+
+describe('lex/tokenizer properties', () => {
+	describe('safety properties', () => {
+		it('never throws on arbitrary string input', () => {
+			fc.assert(
+				fc.property(fc.string(), (input) => {
+					const ctx = new CompilationContext(input)
+					tokenize(ctx)
+					return true
+				}),
+				{ numRuns: 1000 }
+			)
+		})
+	})
+})

--- a/packages/compiler/test/lex/tokenizer.property.test.ts
+++ b/packages/compiler/test/lex/tokenizer.property.test.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import fc from 'fast-check'
 import { CompilationContext } from '../../src/core/context.ts'
@@ -12,6 +11,17 @@ describe('lex/tokenizer properties', () => {
 					const ctx = new CompilationContext(input)
 					tokenize(ctx)
 					return true
+				}),
+				{ numRuns: 1000 }
+			)
+		})
+
+		it('always produces at least an EOF token', () => {
+			fc.assert(
+				fc.property(fc.string(), (input) => {
+					const ctx = new CompilationContext(input)
+					tokenize(ctx)
+					return ctx.tokens.count() >= 1
 				}),
 				{ numRuns: 1000 }
 			)

--- a/packages/compiler/test/lex/tokenizer.property.test.ts
+++ b/packages/compiler/test/lex/tokenizer.property.test.ts
@@ -4,10 +4,12 @@ import { CompilationContext } from '../../src/core/context.ts'
 import { TokenKind } from '../../src/core/tokens.ts'
 import { tokenize } from '../../src/lex/tokenizer.ts'
 
-function getTokenSequence(ctx: CompilationContext): Array<{ kind: number; line: number; column: number }> {
+function getTokenSequence(
+	ctx: CompilationContext
+): Array<{ kind: number; line: number; column: number }> {
 	const tokens: Array<{ kind: number; line: number; column: number }> = []
 	for (const [, token] of ctx.tokens) {
-		tokens.push({ kind: token.kind, line: token.line, column: token.column })
+		tokens.push({ column: token.column, kind: token.kind, line: token.line })
 	}
 	return tokens
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@types/node':
         specifier: 25.0.6
         version: 25.0.6
+      fast-check:
+        specifier: 4.5.3
+        version: 4.5.3
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -270,6 +273,10 @@ packages:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
 
+  fast-check@4.5.3:
+    resolution: {integrity: sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA==}
+    engines: {node: '>=12.17.0'}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
@@ -369,6 +376,9 @@ packages:
 
   printable-characters@1.0.42:
     resolution: {integrity: sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==}
+
+  pure-rand@7.0.1:
+    resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -664,6 +674,10 @@ snapshots:
 
   environment@1.1.0: {}
 
+  fast-check@4.5.3:
+    dependencies:
+      pure-rand: 7.0.1
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -745,6 +759,8 @@ snapshots:
   pretty-hrtime@1.0.3: {}
 
   printable-characters@1.0.42: {}
+
+  pure-rand@7.0.1: {}
 
   queue-microtask@1.2.3: {}
 


### PR DESCRIPTION
## Summary

- Add 51 parser edge case tests for operator precedence and identifier handling
- Add property-based testing infrastructure using fast-check
- Add 6 tokenizer property tests (1000 iterations each):
  - Never throws on arbitrary input
  - Always produces EOF token
  - Final token is always EOF
  - Deterministic output
  - Valid line/column positions (≥1)
  - Balanced INDENT/DEDENT count

## Test plan

- [x] `mise run test` passes
- [x] `mise run typecheck` passes
- [x] `mise run check` passes
- [x] Property tests pass with 1000 iterations each