### PR TITLE
test(parser): add property-based tests

### DIFF
--- a/packages/compiler/test/parse/parser.property.test.ts
+++ b/packages/compiler/test/parse/parser.property.test.ts
@@ -111,5 +111,25 @@ describe('parse/parser properties', () => {
 				{ numRuns: 1000 }
 			)
 		})
+
+		it('all node tokenIds reference valid tokens', () => {
+			fc.assert(
+				fc.property(fc.string(), (input) => {
+					const ctx = new CompilationContext(input)
+					tokenize(ctx)
+					const result = parse(ctx)
+					if (result.succeeded) {
+						const tokenCount = ctx.tokens.count()
+						for (const [, node] of ctx.nodes) {
+							if (node.tokenId < 0 || node.tokenId >= tokenCount) {
+								return false
+							}
+						}
+					}
+					return true
+				}),
+				{ numRuns: 1000 }
+			)
+		})
 	})
 })

--- a/packages/compiler/test/parse/parser.property.test.ts
+++ b/packages/compiler/test/parse/parser.property.test.ts
@@ -1,0 +1,48 @@
+import { describe, it } from 'node:test'
+import fc from 'fast-check'
+import { CompilationContext } from '../../src/core/context.ts'
+import { tokenize } from '../../src/lex/tokenizer.ts'
+import { parse } from '../../src/parse/parser.ts'
+
+describe('parse/parser properties', () => {
+	describe('safety properties', () => {
+		it('never throws on any tokenized input', () => {
+			fc.assert(
+				fc.property(fc.string(), (input) => {
+					const ctx = new CompilationContext(input)
+					tokenize(ctx)
+					parse(ctx)
+					return true
+				}),
+				{ numRuns: 1000 }
+			)
+		})
+
+		it('always returns a result with succeeded boolean', () => {
+			fc.assert(
+				fc.property(fc.string(), (input) => {
+					const ctx = new CompilationContext(input)
+					tokenize(ctx)
+					const result = parse(ctx)
+					return typeof result.succeeded === 'boolean'
+				}),
+				{ numRuns: 1000 }
+			)
+		})
+
+		it('if parsing fails, at least one diagnostic is emitted', () => {
+			fc.assert(
+				fc.property(fc.string(), (input) => {
+					const ctx = new CompilationContext(input)
+					tokenize(ctx)
+					const result = parse(ctx)
+					if (!result.succeeded) {
+						return ctx.getDiagnostics().length >= 1
+					}
+					return true
+				}),
+				{ numRuns: 1000 }
+			)
+		})
+	})
+})


### PR DESCRIPTION
## Summary

- Add 10 parser property tests using fast-check (1000 iterations each)
- Safety properties: never throws, returns result, failed emits diagnostic
- Structural properties: root is Program, node count >= 1, subtreeSize valid, tokenIds valid, postorder invariant
- Determinism property: same input produces same output

## Test Plan

- [x] `mise run test` passes
- [x] `mise run check` passes
- [x] All 10 property tests pass with 1000 iterations