### PR TITLE
test(pipeline): add property-based tests for compilation pipeline

### DIFF
--- a/packages/compiler/test/compile.property.test.ts
+++ b/packages/compiler/test/compile.property.test.ts
@@ -2,6 +2,29 @@ import { describe, it } from 'node:test'
 import fc from 'fast-check'
 import { compile, CompileError } from '../src/index.ts'
 
+// Generator for valid TinyWhale programs
+const validProgramArb = fc.oneof(
+	// Single panic
+	fc.constant('panic\n'),
+	// Multiple panics
+	fc.integer({ min: 1, max: 10 }).map((n) => 'panic\n'.repeat(n)),
+	// Variable binding with panic
+	fc.tuple(
+		fc.constantFrom('i32', 'i64', 'f32', 'f64'),
+		fc.integer({ min: 0, max: 1000 })
+	).map(([type, value]) => {
+		if (type === 'f32' || type === 'f64') {
+			return `x:${type} = ${value}.0\npanic\n`
+		}
+		return `x:${type} = ${value}\npanic\n`
+	}),
+	// Multiple bindings with panic
+	fc.integer({ min: 1, max: 5 }).map((n) => {
+		const bindings = Array.from({ length: n }, (_, i) => `v${i}:i32 = ${i}`).join('\n')
+		return `${bindings}\npanic\n`
+	})
+)
+
 describe('compile/pipeline properties', () => {
 	describe('safety properties', () => {
 		it('never throws non-CompileError exceptions on arbitrary input', () => {

--- a/packages/compiler/test/compile.property.test.ts
+++ b/packages/compiler/test/compile.property.test.ts
@@ -1,0 +1,39 @@
+import { describe, it } from 'node:test'
+import fc from 'fast-check'
+import { compile, CompileError } from '../src/index.ts'
+
+describe('compile/pipeline properties', () => {
+	describe('safety properties', () => {
+		it('never throws non-CompileError exceptions on arbitrary input', () => {
+			fc.assert(
+				fc.property(fc.string(), (input) => {
+					try {
+						compile(input)
+						return true
+					} catch (e) {
+						return e instanceof CompileError
+					}
+				}),
+				{ numRuns: 1000 }
+			)
+		})
+
+		it('always returns a result or throws CompileError', () => {
+			fc.assert(
+				fc.property(fc.string(), (input) => {
+					try {
+						const result = compile(input)
+						return (
+							typeof result.valid === 'boolean' &&
+							result.binary instanceof Uint8Array &&
+							typeof result.text === 'string'
+						)
+					} catch (e) {
+						return e instanceof CompileError
+					}
+				}),
+				{ numRuns: 1000 }
+			)
+		})
+	})
+})

--- a/packages/compiler/test/compile.property.test.ts
+++ b/packages/compiler/test/compile.property.test.ts
@@ -148,10 +148,7 @@ describe('compile/pipeline properties', () => {
 					const normal = compile(source, { optimize: false })
 					const optimized = compile(source, { optimize: true })
 					const checkMagic = (binary: Uint8Array) =>
-						binary[0] === 0x00 &&
-						binary[1] === 0x61 &&
-						binary[2] === 0x73 &&
-						binary[3] === 0x6d
+						binary[0] === 0x00 && binary[1] === 0x61 && binary[2] === 0x73 && binary[3] === 0x6d
 					return checkMagic(normal.binary) && checkMagic(optimized.binary)
 				}),
 				{ numRuns: 100 }
@@ -162,35 +159,28 @@ describe('compile/pipeline properties', () => {
 	describe('semantic preservation properties', () => {
 		it('panic count in source equals unreachable count in WAT', () => {
 			fc.assert(
-				fc.property(
-					fc.integer({ min: 1, max: 10 }),
-					(panicCount) => {
-						const source = 'panic\n'.repeat(panicCount)
-						const result = compile(source)
-						const unreachableCount = (result.text.match(/unreachable/g) || []).length
-						return unreachableCount === panicCount
-					}
-				),
+				fc.property(fc.integer({ max: 10, min: 1 }), (panicCount) => {
+					const source = 'panic\n'.repeat(panicCount)
+					const result = compile(source)
+					const unreachableCount = (result.text.match(/unreachable/g) || []).length
+					return unreachableCount === panicCount
+				}),
 				{ numRuns: 100 }
 			)
 		})
 
 		it('variable binding count equals local count in WAT', () => {
 			fc.assert(
-				fc.property(
-					fc.integer({ min: 1, max: 5 }),
-					(bindingCount) => {
-						const bindings = Array.from(
-							{ length: bindingCount },
-							(_, i) => `v${i}:i32 = ${i}`
-						).join('\n')
-						const source = `${bindings}\npanic\n`
-						const result = compile(source)
-						// Count (local $v... declarations in WAT
-						const localCount = (result.text.match(/\(local \$/g) || []).length
-						return localCount === bindingCount
-					}
-				),
+				fc.property(fc.integer({ max: 5, min: 1 }), (bindingCount) => {
+					const bindings = Array.from({ length: bindingCount }, (_, i) => `v${i}:i32 = ${i}`).join(
+						'\n'
+					)
+					const source = `${bindings}\npanic\n`
+					const result = compile(source)
+					// Count (local $v... declarations in WAT
+					const localCount = (result.text.match(/\(local \$/g) || []).length
+					return localCount === bindingCount
+				}),
 				{ numRuns: 100 }
 			)
 		})

--- a/packages/compiler/test/compile.property.test.ts
+++ b/packages/compiler/test/compile.property.test.ts
@@ -1,28 +1,31 @@
 import { describe, it } from 'node:test'
 import fc from 'fast-check'
-import { compile, CompileError } from '../src/index.ts'
+import { CompileError, compile } from '../src/index.ts'
 
 // Generator for valid TinyWhale programs
 const validProgramArb = fc.oneof(
 	// Single panic
 	fc.constant('panic\n'),
 	// Multiple panics
-	fc.integer({ min: 1, max: 10 }).map((n) => 'panic\n'.repeat(n)),
+	fc
+		.integer({ max: 10, min: 1 })
+		.map((n) => 'panic\n'.repeat(n)),
 	// Variable binding with panic
-	fc.tuple(
-		fc.constantFrom('i32', 'i64', 'f32', 'f64'),
-		fc.integer({ min: 0, max: 1000 })
-	).map(([type, value]) => {
-		if (type === 'f32' || type === 'f64') {
-			return `x:${type} = ${value}.0\npanic\n`
-		}
-		return `x:${type} = ${value}\npanic\n`
-	}),
+	fc
+		.tuple(fc.constantFrom('i32', 'i64', 'f32', 'f64'), fc.integer({ max: 1000, min: 0 }))
+		.map(([type, value]) => {
+			if (type === 'f32' || type === 'f64') {
+				return `x:${type} = ${value}.0\npanic\n`
+			}
+			return `x:${type} = ${value}\npanic\n`
+		}),
 	// Multiple bindings with panic
-	fc.integer({ min: 1, max: 5 }).map((n) => {
-		const bindings = Array.from({ length: n }, (_, i) => `v${i}:i32 = ${i}`).join('\n')
-		return `${bindings}\npanic\n`
-	})
+	fc
+		.integer({ max: 5, min: 1 })
+		.map((n) => {
+			const bindings = Array.from({ length: n }, (_, i) => `v${i}:i32 = ${i}`).join('\n')
+			return `${bindings}\npanic\n`
+		})
 )
 
 describe('compile/pipeline properties', () => {
@@ -56,6 +59,58 @@ describe('compile/pipeline properties', () => {
 					}
 				}),
 				{ numRuns: 1000 }
+			)
+		})
+	})
+
+	describe('WASM validity properties', () => {
+		it('binary starts with WASM magic number (\\0asm)', () => {
+			fc.assert(
+				fc.property(validProgramArb, (source) => {
+					const result = compile(source)
+					return (
+						result.binary[0] === 0x00 &&
+						result.binary[1] === 0x61 &&
+						result.binary[2] === 0x73 &&
+						result.binary[3] === 0x6d
+					)
+				}),
+				{ numRuns: 100 }
+			)
+		})
+
+		it('binary starts with WASM version 1', () => {
+			fc.assert(
+				fc.property(validProgramArb, (source) => {
+					const result = compile(source)
+					return (
+						result.binary[4] === 0x01 &&
+						result.binary[5] === 0x00 &&
+						result.binary[6] === 0x00 &&
+						result.binary[7] === 0x00
+					)
+				}),
+				{ numRuns: 100 }
+			)
+		})
+
+		it('WAT text contains (module', () => {
+			fc.assert(
+				fc.property(validProgramArb, (source) => {
+					const result = compile(source)
+					return result.text.includes('(module')
+				}),
+				{ numRuns: 100 }
+			)
+		})
+
+		it('WAT text contains (export "_start"', () => {
+			fc.assert(
+				fc.property(validProgramArb, (source) => {
+					const result = compile(source)
+					return result.text.includes('(export "_start"')
+				}),
+				{ numRuns: 100 }
 			)
 		})
 	})


### PR DESCRIPTION
## Summary
- Add property-based tests for the full compilation pipeline (Phase 3)
- 11 property tests covering safety, WASM validity, consistency, and semantic preservation
- Includes valid program generator for testing successful compilation paths

## Test Plan
- [x] All 11 property tests pass
- [x] Full test suite passes (`mise run test`)
- [x] Linting passes (`mise run check`)