### PR TITLE
feat: implement refinement types in field declarations (D7)

### DIFF
--- a/packages/compiler/src/core/nodes.ts
+++ b/packages/compiler/src/core/nodes.ts
@@ -20,7 +20,7 @@ export const NodeKind = {
 	FloatLiteral: 103,
 
 	Hint: 153,
-	HintedPrimitive: 154,
+	RefinementType: 154,
 
 	Identifier: 100,
 	IndentedLine: 0,

--- a/packages/compiler/src/core/nodes.ts
+++ b/packages/compiler/src/core/nodes.ts
@@ -20,7 +20,6 @@ export const NodeKind = {
 	FloatLiteral: 103,
 
 	Hint: 153,
-	RefinementType: 154,
 
 	Identifier: 100,
 	IndentedLine: 0,
@@ -42,6 +41,7 @@ export const NodeKind = {
 	Program: 255,
 	RecordBinding: 15,
 	RecordLiteral: 107,
+	RefinementType: 154,
 	RootLine: 2,
 	SizeHint: 152,
 	TypeAnnotation: 150,

--- a/packages/compiler/src/parse/parser.ts
+++ b/packages/compiler/src/parse/parser.ts
@@ -286,15 +286,15 @@ function createNodeEmittingSemantics(
 		return typeNode.child(0).ctorName === 'ListType'
 	}
 
-	function isHintedPrimitiveRef(typeNode: Node): boolean {
+	function isRefinementTypeRef(typeNode: Node): boolean {
 		if (typeNode.ctorName !== 'TypeRef') return false
-		return typeNode.child(0).ctorName === 'HintedPrimitive'
+		return typeNode.child(0).ctorName === 'RefinementType'
 	}
 
 	function maybeEmitComplexType(typeNode: Node): void {
 		if (isListTypeRef(typeNode)) {
 			typeNode.child(0)['emitTypeAnnotation']()
-		} else if (isHintedPrimitiveRef(typeNode)) {
+		} else if (isRefinementTypeRef(typeNode)) {
 			typeNode.child(0)['emitTypeAnnotation']()
 		}
 	}
@@ -454,14 +454,14 @@ function createNodeEmittingSemantics(
 				tokenId: valueTid,
 			})
 		},
-		HintedPrimitive(_typeKeyword: Node, typeHints: Node): NodeId {
+		RefinementType(_typeKeyword: Node, typeHints: Node): NodeId {
 			const startCount = context.nodes.count()
 			typeHints['emitTypeAnnotation']()
 			const childCount = context.nodes.count() - startCount
 
 			const tid = getTokenIdForOhmNode(this)
 			return context.nodes.add({
-				kind: NodeKind.HintedPrimitive,
+				kind: NodeKind.RefinementType,
 				subtreeSize: 1 + childCount,
 				tokenId: tid,
 			})
@@ -469,7 +469,7 @@ function createNodeEmittingSemantics(
 		ListType(elementType: Node, suffixes: Node): NodeId {
 			const startCount = context.nodes.count()
 			// Handle hinted primitives as base element type
-			if (elementType.ctorName === 'HintedPrimitive') {
+			if (elementType.ctorName === 'RefinementType') {
 				elementType['emitTypeAnnotation']()
 			}
 			// Emit each list type suffix (each is []<size=N>)
@@ -696,7 +696,7 @@ function createNodeEmittingSemantics(
 			// Emit type annotation node with possible complex type children
 			// typeRef is PrimitiveTypeRef, need to check its child for the actual type
 			const innerType = typeRef.child(0)
-			if (innerType.ctorName === 'ListType' || innerType.ctorName === 'HintedPrimitive') {
+			if (innerType.ctorName === 'ListType' || innerType.ctorName === 'RefinementType') {
 				innerType['emitTypeAnnotation']()
 			}
 

--- a/packages/compiler/src/parse/tinywhale.ohm
+++ b/packages/compiler/src/parse/tinywhale.ohm
@@ -26,7 +26,7 @@ TinyWhale {
   TypeDecl = typeKeywordToken upperIdentifier
 
   // Primitive type reference (types that require inline expression)
-  PrimitiveTypeRef = ListType | HintedPrimitive | typeKeyword
+  PrimitiveTypeRef = ListType | RefinementType | typeKeyword
 
   // Binding for primitive types: expression required
   PrimitiveBinding = identifier colon PrimitiveTypeRef equals Expression
@@ -49,10 +49,10 @@ TinyWhale {
 
   // Type reference (primitives or user-defined)
   // ListType handles iterative nesting: i32[]<size=4>[]<size=2>
-  TypeRef = ListType | HintedPrimitive | upperIdentifier | typeKeyword
+  TypeRef = ListType | RefinementType | upperIdentifier | typeKeyword
 
-  // Hinted primitive: i32<min=0, max=100>
-  HintedPrimitive = typeKeyword TypeHints
+  // Refinement type: i32<min=0, max=100>
+  RefinementType = typeKeyword TypeHints
 
   // Type hints for constraints: <min=0, max=100> or <size=4>
   TypeHints = lessThan HintList greaterThan
@@ -66,7 +66,7 @@ TinyWhale {
   // Uses iterative suffixes to avoid left recursion
   ListType = ListTypeBase ListTypeSuffix+
   ListTypeSuffix = lbracket rbracket TypeHints
-  ListTypeBase = HintedPrimitive | upperIdentifier | typeKeyword
+  ListTypeBase = RefinementType | upperIdentifier | typeKeyword
   sizeKeyword = "size" ~identifierPart
 
   // Upper-case identifier for type names

--- a/packages/compiler/test/semantic-specs.test.ts
+++ b/packages/compiler/test/semantic-specs.test.ts
@@ -156,7 +156,8 @@ test('Semantic Specs', async (t) => {
 			{
 				description: 'multiple refinement fields',
 				expect: 'valid',
-				input: 'type Bounded\n\ta: i32<min=0, max=100>\n\tb: i32<min=-10>\np:Bounded =\n\ta: 50\n\tb: -5',
+				input:
+					'type Bounded\n\ta: i32<min=0, max=100>\n\tb: i32<min=-10>\np:Bounded =\n\ta: 50\n\tb: -5',
 			},
 			{
 				description: 'refinement field max constraint violated',

--- a/packages/compiler/test/semantic-specs.test.ts
+++ b/packages/compiler/test/semantic-specs.test.ts
@@ -142,6 +142,28 @@ test('Semantic Specs', async (t) => {
 				expect: 'check-error',
 				input: 'type Point\n\tx: i32\n\ty: i32\np:Point =\n\tx: 1',
 			},
+			{
+				description: 'refinement type in field - constraint satisfied',
+				expect: 'valid',
+				input: 'type Point\n\tx: i32<min=0>\n\ty: i32\np:Point =\n\tx: 5\n\ty: 10',
+			},
+			{
+				description: 'refinement type in field - constraint violated',
+				errorCode: 'TWCHECK041',
+				expect: 'check-error',
+				input: 'type Point\n\tx: i32<min=0>\n\ty: i32\np:Point =\n\tx: -5\n\ty: 10',
+			},
+			{
+				description: 'multiple refinement fields',
+				expect: 'valid',
+				input: 'type Bounded\n\ta: i32<min=0, max=100>\n\tb: i32<min=-10>\np:Bounded =\n\ta: 50\n\tb: -5',
+			},
+			{
+				description: 'refinement field max constraint violated',
+				errorCode: 'TWCHECK041',
+				expect: 'check-error',
+				input: 'type Bounded\n\ta: i32<max=10>\np:Bounded =\n\ta: 100',
+			},
 		])
 	)
 


### PR DESCRIPTION
## Summary
- Rename `HintedPrimitive` to `RefinementType` throughout grammar and code
- Fix `processFieldDecl` to traverse parse nodes instead of using hardcoded token offsets
- Parser now emits `RefinementType` as child of `FieldDecl` nodes
- Constraints (min/max) are now properly enforced on record field initialization

## Test Plan
- [x] Added 4 semantic tests for refinement types in fields
- [x] All 702 tests pass
- [x] CI passes
- [x] Updated discrepancies documentation (D7 moved to working section)

## Example
```tinywhale
type Point
    x: i32<min=0, max=100>
    y: i32
p:Point =
    x: 50   # Valid
    y: 10
```

Previously, constraints on field declarations were silently ignored. Now they are enforced.