### PR TITLE
feat: cleaner record initialization syntax

### DIFF
--- a/docs/2026-01-20-grammar-semantic-discrepancies.md
+++ b/docs/2026-01-20-grammar-semantic-discrepancies.md
@@ -390,6 +390,28 @@ RefinementType = typeKeyword TypeHints
 
 ---
 
+### 22. Cleaner Record Initialization Syntax
+
+```tinywhale
+type Point
+    x: i32
+    y: i32
+
+p:Point
+    x = 50
+    y = 10
+```
+
+Record binding uses `:` for type name only (no trailing `=`). Field values use `=`. Nested record construction uses `:` with type name.
+
+```ohm
+RecordBinding = identifier colon upperIdentifier
+FieldInit = lowerIdentifier equals Expression
+FieldDecl = lowerIdentifier colon TypeRef  // Also used for nested record init
+```
+
+---
+
 ## Discrepancies
 
 ### D1. Nested Lists
@@ -680,7 +702,7 @@ Not yet implemented. Will unlock:
 
 | Category | Count |
 |----------|-------|
-| Working correctly | 21 |
+| Working correctly | 22 |
 | Discrepancies | 9 |
 | Future enhancements | 5 |
 

--- a/packages/compiler/src/check/checker.ts
+++ b/packages/compiler/src/check/checker.ts
@@ -334,6 +334,17 @@ function finalizeNestedContextsForIndent(
 	}
 }
 
+function tryStartNestedRecordInit(
+	lineId: NodeId,
+	lineIndentLevel: number | null,
+	state: CheckerState,
+	context: CompilationContext
+): boolean {
+	return (
+		lineIndentLevel !== null && maybeStartNestedRecordInit(lineId, lineIndentLevel, state, context)
+	)
+}
+
 function handleIndentedLine(
 	lineId: NodeId,
 	state: CheckerState,
@@ -344,7 +355,7 @@ function handleIndentedLine(
 
 	if (processIndentedLineAsMatchArm(lineId, state, context)) return
 	if (processIndentedLineAsFieldDecl(lineId, state, context)) return
-	if (lineIndentLevel !== null && maybeStartNestedRecordInit(lineId, lineIndentLevel, state, context)) return
+	if (tryStartNestedRecordInit(lineId, lineIndentLevel, state, context)) return
 	if (processIndentedLineAsFieldInit(lineId, state, context)) return
 	context.emitAtNode('TWCHECK001' as DiagnosticCode, lineId)
 }

--- a/packages/compiler/src/check/checker.ts
+++ b/packages/compiler/src/check/checker.ts
@@ -177,7 +177,6 @@ function emitStatement(
 			}
 			break
 		case NodeKind.MatchExpr:
-			// Standalone match expression (discarded form) - not yet implemented
 			break
 	}
 }
@@ -258,7 +257,6 @@ function processIndentedLineAsFieldDecl(
 ): boolean {
 	if (!isInTypeDeclContext(state)) return false
 
-	// Handle FieldDecl for primitive type fields
 	const fieldDecl = getFieldDeclFromLine(lineId, context)
 	if (fieldDecl) {
 		processFieldDecl(fieldDecl.id, state, context)
@@ -280,11 +278,7 @@ function maybeStartNestedRecordInit(
 ): boolean {
 	const fieldDecl = getFieldDeclFromLineForInit(lineId, context)
 	if (!fieldDecl) return false
-
-	// Only start nested record init if in record literal context
 	if (!isInRecordInitContext(state)) return false
-
-	// Check if it's an uppercase TypeRef (user-defined type)
 	if (!hasUppercaseTypeRef(fieldDecl.id, context)) {
 		return false
 	}
@@ -365,14 +359,12 @@ function processDedentLineStatement(
 	state: CheckerState,
 	context: CompilationContext
 ): void {
-	// Check for TypeDecl first (needs special context setup)
 	const typeDecl = getTypeDeclFromLine(lineId, context)
 	if (typeDecl) {
 		startTypeDecl(typeDecl.id, state, context)
 		return
 	}
 
-	// Handle other statements
 	const stmt = getStatementFromLine(lineId, context)
 	if (stmt) emitStatement(stmt.id, stmt.kind, state, context)
 }
@@ -401,14 +393,12 @@ function handleDedentLine(lineId: NodeId, state: CheckerState, context: Compilat
 		return
 	}
 
-	// Finalize pending record literal and process statement
 	if (isInRecordLiteralContext(state)) {
 		finalizeRecordLiteral(state, context)
 		processDedentLineStatement(lineId, state, context)
 		return
 	}
 
-	// No context - error
 	context.emitAtNode('TWCHECK001' as DiagnosticCode, lineId)
 }
 
@@ -532,7 +522,6 @@ export function check(context: CompilationContext): CheckResult {
 		unreachableRange: null,
 	}
 
-	// Find Program node (last node in postorder storage)
 	const nodeCount = context.nodes.count()
 	if (nodeCount === 0) {
 		assignCheckResultsToContext(context, insts, symbols, types)
@@ -543,12 +532,10 @@ export function check(context: CompilationContext): CheckResult {
 	const program = context.nodes.get(programId)
 
 	if (program.kind !== NodeKind.Program) {
-		// No valid Program node - might be a parse error
 		assignCheckResultsToContext(context, insts, symbols, types)
 		return { succeeded: !context.hasErrors() }
 	}
 
-	// Process line children in source order
 	const lines = getLineChildrenInSourceOrder(programId, context)
 	for (const [lineId, line] of lines) {
 		processLine(lineId, line, state, context)

--- a/packages/compiler/src/check/records.ts
+++ b/packages/compiler/src/check/records.ts
@@ -25,7 +25,6 @@ import {
 	popBlockContext,
 	pushBlockContext,
 	type RecordLiteralContext,
-	type TypeDeclContext,
 } from './state.ts'
 import { type FieldInfo, InstKind, type SymbolId, type TypeId } from './types.ts'
 
@@ -169,42 +168,6 @@ export function processFieldInitInNestedContext(
 
 	ctx.fieldNames.add(fieldName)
 	ctx.fieldInits.push({ exprResult, name: fieldName, nodeId: fieldInitId })
-}
-
-/**
- * Extract field info from a FieldInit with NestedRecordInit for type declaration.
- * Note: NestedRecordInit no longer exists in the grammar. This function is kept
- * for backward compatibility but returns null. TypeDecl fields are now handled
- * via FieldDecl nodes directly.
- */
-function extractTypeDeclFieldInfo(
-	_fieldInitId: NodeId,
-	_state: CheckerState,
-	_context: CompilationContext
-): { ctx: TypeDeclContext; fieldName: string; typeId: TypeId } | null {
-	// NestedRecordInit no longer exists - TypeDecl uses FieldDecl directly
-	return null
-}
-
-/**
- * Process a FieldInit with NestedRecordInit as a type declaration field.
- * This handles the case where a user-defined type field is parsed as FieldInit.
- */
-export function processFieldInitAsTypeField(
-	fieldInitId: NodeId,
-	state: CheckerState,
-	context: CompilationContext
-): void {
-	const info = extractTypeDeclFieldInfo(fieldInitId, state, context)
-	if (!info) return
-
-	if (info.ctx.fieldNames.has(info.fieldName)) {
-		context.emitAtNode('TWCHECK026' as DiagnosticCode, fieldInitId, { name: info.fieldName })
-		return
-	}
-
-	info.ctx.fieldNames.add(info.fieldName)
-	info.ctx.fields.push({ name: info.fieldName, nodeId: fieldInitId, typeId: info.typeId })
 }
 
 // ============================================================================

--- a/packages/compiler/src/check/records.ts
+++ b/packages/compiler/src/check/records.ts
@@ -69,7 +69,6 @@ export function hasUppercaseTypeRef(fieldDeclId: NodeId, context: CompilationCon
 	const fieldDeclNode = context.nodes.get(fieldDeclId)
 	const typeTokenId = (fieldDeclNode.tokenId as number) + 2
 	const typeToken = context.tokens.get(typeTokenId as typeof fieldDeclNode.tokenId)
-	// Uppercase means user-defined type
 	if (typeToken.kind === TokenKind.Identifier) {
 		const typeName = context.strings.get(typeToken.payload as StringId)
 		const firstChar = typeName[0]
@@ -491,7 +490,6 @@ export function finalizeNestedRecordInit(state: CheckerState, context: Compilati
 	popBlockContext(state)
 	validateNestedRecordMissingFields(ctx, state, context)
 
-	// Emit symbols and bindings for the nested record fields
 	if (!context.hasErrors() && isValidNestedRecordInitCtx(ctx)) {
 		emitFinalizedNestedRecordInit(ctx, state, context)
 	}

--- a/packages/compiler/src/core/nodes.ts
+++ b/packages/compiler/src/core/nodes.ts
@@ -30,8 +30,6 @@ export const NodeKind = {
 	LiteralPattern: 201,
 	MatchArm: 13,
 	MatchExpr: 12,
-
-	NestedRecordInit: 110,
 	OrPattern: 203,
 
 	PanicStatement: 10,

--- a/packages/compiler/src/parse/parser.ts
+++ b/packages/compiler/src/parse/parser.ts
@@ -502,9 +502,7 @@ function createNodeEmittingSemantics(
 		},
 		TypeHints(_lessThan: Node, hintList: Node, _greaterThan: Node): NodeId {
 			const startCount = context.nodes.count()
-			// Emit first hint
 			hintList.child(0)['emitTypeAnnotation']()
-			// Emit rest hints (skipping comma separators)
 			const restHints = hintList.child(2)
 			for (let i = 0; i < restHints.numChildren; i++) {
 				restHints.child(i)['emitTypeAnnotation']()

--- a/packages/compiler/src/parse/parser.ts
+++ b/packages/compiler/src/parse/parser.ts
@@ -588,23 +588,6 @@ function createNodeEmittingSemantics(
 		},
 	})
 
-	semantics.addOperation<NodeId>('emitFieldValue', {
-		FieldValue(value: Node): NodeId {
-			if (value.ctorName === 'NestedRecordInit') {
-				return value['emitFieldValue']()
-			}
-			return value['emitExpression']()
-		},
-		NestedRecordInit(_typeName: Node): NodeId {
-			const tid = getTokenIdForOhmNode(this)
-			return context.nodes.add({
-				kind: NodeKind.NestedRecordInit,
-				subtreeSize: 1,
-				tokenId: tid,
-			})
-		},
-	})
-
 	semantics.addOperation<NodeId>('emitIndentedContent', {
 		FieldDecl(fieldName: Node, _colon: Node, typeRef: Node): NodeId {
 			const startCount = context.nodes.count()
@@ -623,9 +606,9 @@ function createNodeEmittingSemantics(
 				tokenId: tid,
 			})
 		},
-		FieldInit(fieldName: Node, _colon: Node, fieldValue: Node): NodeId {
+		FieldInit(fieldName: Node, _equals: Node, expression: Node): NodeId {
 			const startCount = context.nodes.count()
-			fieldValue['emitFieldValue']()
+			expression['emitExpression']()
 			const childCount = context.nodes.count() - startCount
 
 			const tid = getTokenIdForOhmNode(fieldName)
@@ -729,7 +712,7 @@ function createNodeEmittingSemantics(
 				tokenId: lineTid,
 			})
 		},
-		RecordBinding(ident: Node, _colon: Node, typeName: Node, _equals: Node): NodeId {
+		RecordBinding(ident: Node, _colon: Node, typeName: Node): NodeId {
 			const startCount = context.nodes.count()
 			ident['emitExpression']()
 

--- a/packages/compiler/src/parse/tinywhale.ohm
+++ b/packages/compiler/src/parse/tinywhale.ohm
@@ -11,7 +11,8 @@ TinyWhale {
   newline = "\n" | "\r\n" | "\r"
 
   // IndentedLine can contain a MatchArm, Statement, FieldDecl, or FieldInit
-  // FieldInit comes before FieldDecl: uppercase identifiers are tried as NestedRecordInit first
+  // FieldDecl (with :) for type declarations or nested record init (context-dependent)
+  // FieldInit (with =) for value assignments
   // When dedenting from level N to level M (where M > 0), tokenizer emits both indent and dedent tokens.
   // anyDedent* handles the dedent tokens that follow the indent marker.
   IndentedLine = indentToken anyDedent* IndentedContent?
@@ -32,7 +33,7 @@ TinyWhale {
   PrimitiveBinding = identifier colon PrimitiveTypeRef equals Expression
 
   // Binding for record types: no expression, block follows
-  RecordBinding = identifier colon upperIdentifier equals
+  RecordBinding = identifier colon upperIdentifier
 
   // TypeAnnotation used by MatchBinding
   TypeAnnotation = colon TypeRef
@@ -40,12 +41,8 @@ TinyWhale {
   // Field declaration inside type (on indented line)
   FieldDecl = lowerIdentifier colon TypeRef
 
-  // Field initialization: x: 5 or inner: Inner (nested construction)
-  FieldInit = lowerIdentifier colon FieldValue
-  FieldValue = NestedRecordInit | Expression
-
-  // Nested record construction (typename signals block follows)
-  NestedRecordInit = upperIdentifier
+  // Field value initialization: x = 50
+  FieldInit = lowerIdentifier equals Expression
 
   // Type reference (primitives or user-defined)
   // ListType handles iterative nesting: i32[]<size=4>[]<size=2>

--- a/packages/compiler/test/check/list-types.test.ts
+++ b/packages/compiler/test/check/list-types.test.ts
@@ -163,8 +163,8 @@ panic`
 		it('documents expected: list field init in record should work', () => {
 			const source = `type Data
     items: i32[]<size=1>
-d: Data =
-    items: [99]
+d:Data
+    items = [99]
 panic`
 			const ctx = prepareAndCheck(source)
 

--- a/packages/compiler/test/grammar-specs.test.ts
+++ b/packages/compiler/test/grammar-specs.test.ts
@@ -408,6 +408,21 @@ test('Grammar Specs', async (t) => {
 			])
 		)
 
+		// New syntax tests: = for values, : for types only
+		tester.match(
+			prepareList([
+				'type Point\n\tx: i32\np:Point\n\tx = 5', // New: no = after type, = for field value
+				'type Point\n\tx: i32\n\ty: i32\np:Point\n\tx = 5\n\ty = 10', // Multiple fields
+				'type Inner\n\tval: i32\ntype Outer\n\tinner: Inner\no:Outer\n\tinner: Inner\n\t\tval = 5', // Nested
+			])
+		)
+		tester.reject(
+			prepareList([
+				'type Point\n\tx: i32\np:Point =\n\tx = 5', // Old syntax: = after type name rejected
+				'type Point\n\tx: i32\np:Point\n\tx: 5', // Old syntax: : for values rejected
+			])
+		)
+
 		const result = tester.run()
 		if (result.failed > 0) {
 			for (const r of result.results) {

--- a/packages/compiler/test/grammar-specs.test.ts
+++ b/packages/compiler/test/grammar-specs.test.ts
@@ -102,7 +102,7 @@ test('Grammar Specs', async (t) => {
 				'x:i32<min=0> = 5', // [FULL] - type hints with constraint checking
 				'x:i32<min=0, max=100> = 50', // [FULL]
 				'arr:i32[]<size=3> = [1, 2, 3]', // [FULL] - single-level list
-				'p:Point =', // [FULL] - record binding, block follows
+				'p:Point', // [FULL] - record binding (new syntax: no trailing =)
 			])
 		)
 
@@ -115,6 +115,7 @@ test('Grammar Specs', async (t) => {
 				'x:i32<min=0> =', // Missing expression for hinted primitive
 				'arr:i32[]<size=3> =', // Missing expression for list type
 				'p:Point = 5', // Expression not allowed for record
+				'p:Point =', // Old syntax: trailing = after record type rejected
 			])
 		)
 
@@ -397,29 +398,28 @@ test('Grammar Specs', async (t) => {
 	await t.test('Record Initialization', (t) => {
 		const tester = createTester(grammar, 'Record Initialization', 'Program')
 
+		// New syntax: = for values, : for types only
 		tester.match(
 			prepareList([
 				// Simple record with fields
-				'type Point\n\tx: i32\n\ty: i32\np:Point =\n\tx: 1\n\ty: 2',
+				'type Point\n\tx: i32\n\ty: i32\np:Point\n\tx = 1\n\ty = 2',
 				// Record with list field
-				'type Foo\n\titems: i32[]<size=3>\nf:Foo =\n\titems: [1, 2, 3]',
+				'type Foo\n\titems: i32[]<size=3>\nf:Foo\n\titems = [1, 2, 3]',
 				// Nested record initialization
-				'type Inner\n\tvalue: i32\ntype Outer\n\tinner: Inner\no:Outer =\n\tinner: Inner\n\t\tvalue: 42',
-			])
-		)
-
-		// New syntax tests: = for values, : for types only
-		tester.match(
-			prepareList([
-				'type Point\n\tx: i32\np:Point\n\tx = 5', // New: no = after type, = for field value
+				'type Inner\n\tvalue: i32\ntype Outer\n\tinner: Inner\no:Outer\n\tinner: Inner\n\t\tvalue = 42',
+				// Additional new syntax tests
+				'type Point\n\tx: i32\np:Point\n\tx = 5', // no = after type, = for field value
 				'type Point\n\tx: i32\n\ty: i32\np:Point\n\tx = 5\n\ty = 10', // Multiple fields
 				'type Inner\n\tval: i32\ntype Outer\n\tinner: Inner\no:Outer\n\tinner: Inner\n\t\tval = 5', // Nested
 			])
 		)
+
+		// Old syntax should be rejected
 		tester.reject(
 			prepareList([
 				'type Point\n\tx: i32\np:Point =\n\tx = 5', // Old syntax: = after type name rejected
 				'type Point\n\tx: i32\np:Point\n\tx: 5', // Old syntax: : for values rejected
+				'type Point\n\tx: i32\np:Point =\n\tx: 5', // Old syntax: both = after type and : for value
 			])
 		)
 

--- a/packages/compiler/test/parse/parser.test.ts
+++ b/packages/compiler/test/parse/parser.test.ts
@@ -844,8 +844,8 @@ panic`
 		it('should parse record initialization with list field', () => {
 			const source = `type Foo
     items: i32[]<size=3>
-f: Foo =
-    items: [1, 2, 3]
+f:Foo
+    items = [1, 2, 3]
 panic`
 			const ctx = new CompilationContext(source)
 			tokenize(ctx)
@@ -856,8 +856,8 @@ panic`
 		it('should parse record initialization with nested list field', () => {
 			const source = `type Matrix
     data: i32[]<size=2>[]<size=2>
-m: Matrix =
-    data: [[1, 2], [3, 4]]
+m:Matrix
+    data = [[1, 2], [3, 4]]
 panic`
 			const ctx = new CompilationContext(source)
 			tokenize(ctx)
@@ -869,9 +869,9 @@ panic`
 			const source = `type Data
     xs: i32[]<size=2>
     ys: i32[]<size=2>
-d: Data =
-    xs: [1, 2]
-    ys: [3, 4]
+d:Data
+    xs = [1, 2]
+    ys = [3, 4]
 panic`
 			const ctx = new CompilationContext(source)
 			tokenize(ctx)

--- a/packages/compiler/test/record-types.property.test.ts
+++ b/packages/compiler/test/record-types.property.test.ts
@@ -82,9 +82,9 @@ function generateRecordInit(
 	values: number[]
 ): string {
 	const fieldInits = fields
-		.map((f, i) => `    ${f.name}: ${literalForType(f.type, values[i] ?? 0)}`)
+		.map((f, i) => `    ${f.name} = ${literalForType(f.type, values[i] ?? 0)}`)
 		.join('\n')
-	return `${varName}: ${typeName} =\n${fieldInits}`
+	return `${varName}:${typeName}\n${fieldInits}`
 }
 
 // ============================================================================
@@ -663,11 +663,11 @@ function generateNestedTypes(depth: number): string {
  * Generate nested record initialization for a given depth
  */
 function generateNestedInit(depth: number, value: number): string {
-	let init = `o: T0 =\n`
+	let init = `o:T0\n`
 	for (let i = 0; i < depth - 1; i++) {
 		init += `${'    '.repeat(i + 1)}inner: T${i + 1}\n`
 	}
-	init += `${'    '.repeat(depth)}val: ${value}\n`
+	init += `${'    '.repeat(depth)}val = ${value}\n`
 	return init
 }
 
@@ -703,15 +703,15 @@ function generateNestedInitWithSiblings(
 	leafValue: number,
 	siblingValues: number[]
 ): string {
-	let init = 'o: T0 =\n'
+	let init = 'o:T0\n'
 	for (let i = 0; i < depth - 1; i++) {
 		init += `${'    '.repeat(i + 1)}inner: T${i + 1}\n`
 	}
 	// Leaf value
-	init += `${'    '.repeat(depth)}val: ${leafValue}\n`
+	init += `${'    '.repeat(depth)}val = ${leafValue}\n`
 	// Sibling fields (in reverse order from deepest to shallowest)
 	for (let i = depth - 2; i >= 0; i--) {
-		init += `${'    '.repeat(i + 1)}sib${i}: ${siblingValues[i] ?? 0}\n`
+		init += `${'    '.repeat(i + 1)}sib${i} = ${siblingValues[i] ?? 0}\n`
 	}
 	return init
 }
@@ -836,8 +836,8 @@ describe('record types/sibling fields after nested blocks properties', () => {
 
 					// Two orderings of fields in init
 					const init = siblingFirst
-						? `o: Outer =\n    sib: ${sibVal}\n    inner: Inner\n        val: ${innerVal}\n`
-						: `o: Outer =\n    inner: Inner\n        val: ${innerVal}\n    sib: ${sibVal}\n`
+						? `o:Outer\n    sib = ${sibVal}\n    inner: Inner\n        val = ${innerVal}\n`
+						: `o:Outer\n    inner: Inner\n        val = ${innerVal}\n    sib = ${sibVal}\n`
 
 					const source = `${types}${init}panic\n`
 
@@ -911,9 +911,9 @@ describe('record types/sibling fields after nested blocks properties', () => {
 					const types = `type Inner\n    val: i32\ntype Outer\n${typeFields}`
 
 					// Init with nested block first, then all siblings
-					let init = `o: Outer =\n    inner: Inner\n        val: ${values[0] ?? 0}\n`
+					let init = `o:Outer\n    inner: Inner\n        val = ${values[0] ?? 0}\n`
 					for (let i = 0; i < siblingCount; i++) {
-						init += `    s${i}: ${values[i + 1] ?? 0}\n`
+						init += `    s${i} = ${values[i + 1] ?? 0}\n`
 					}
 
 					const source = `${types}${init}panic\n`

--- a/packages/compiler/test/record-types.test.ts
+++ b/packages/compiler/test/record-types.test.ts
@@ -89,9 +89,6 @@ describe('record types node kinds', () => {
 	it('has FieldAccess node kind', () => {
 		assert.ok(NodeKind.FieldAccess !== undefined)
 	})
-	it('has NestedRecordInit node kind', () => {
-		assert.ok(NodeKind.NestedRecordInit !== undefined)
-	})
 })
 
 describe('record types parsing', () => {
@@ -575,7 +572,7 @@ panic`
 		assert.ok(result, 'should parse nested record init')
 	})
 
-	it('creates NestedRecordInit node for type name in field init', () => {
+	it('creates FieldDecl node for type name in nested record init', () => {
 		const source = `o: Outer =
     inner: Inner
         val: 42
@@ -585,8 +582,8 @@ panic`
 		parse(ctx)
 
 		const nodes = [...ctx.nodes]
-		const nestedRecordInit = nodes.find(([, n]) => n.kind === NodeKind.NestedRecordInit)
-		assert.ok(nestedRecordInit, 'should create NestedRecordInit node')
+		const fieldDecl = nodes.find(([, n]) => n.kind === NodeKind.FieldDecl)
+		assert.ok(fieldDecl, 'should create FieldDecl node for nested record type')
 	})
 })
 

--- a/packages/compiler/test/record-types.test.ts
+++ b/packages/compiler/test/record-types.test.ts
@@ -109,9 +109,9 @@ describe('record literal parsing', () => {
 		const source = `type Point
     x: i32
     y: i32
-p: Point =
-    x: 5
-    y: 10
+p:Point
+    x = 5
+    y = 10
 panic`
 		const ctx = new CompilationContext(source)
 		tokenize(ctx)
@@ -169,9 +169,9 @@ panic`
 	})
 
 	it('creates FieldInit nodes', () => {
-		const source = `p: Point =
-    x: 5
-    y: 10
+		const source = `p:Point
+    x = 5
+    y = 10
 panic`
 		const ctx = new CompilationContext(source)
 		tokenize(ctx)
@@ -268,9 +268,9 @@ describe('checker record instantiation', () => {
 		const source = `type Point
     x: i32
     y: i32
-p: Point =
-    x: 5
-    y: 10
+p:Point
+    x = 5
+    y = 10
 panic`
 		const ctx = createContext(source)
 		tokenize(ctx)
@@ -284,8 +284,8 @@ panic`
 		const source = `type Point
     x: i32
     y: i32
-p: Point =
-    x: 5
+p:Point
+    x = 5
 panic`
 		const ctx = createContext(source)
 		tokenize(ctx)
@@ -299,10 +299,10 @@ panic`
 		const source = `type Point
     x: i32
     y: i32
-p: Point =
-    x: 5
-    y: 10
-    z: 15
+p:Point
+    x = 5
+    y = 10
+    z = 15
 panic`
 		const ctx = createContext(source)
 		tokenize(ctx)
@@ -316,9 +316,9 @@ panic`
 		const source = `type Point
     x: i32
     y: i32
-p: Point =
-    x: 5
-    x: 10
+p:Point
+    x = 5
+    x = 10
 panic`
 		const ctx = createContext(source)
 		tokenize(ctx)
@@ -329,8 +329,8 @@ panic`
 	})
 
 	it('allows record instantiation without type declaration (error expected)', () => {
-		const source = `p: UnknownType =
-    x: 5
+		const source = `p:UnknownType
+    x = 5
 panic`
 		const ctx = createContext(source)
 		tokenize(ctx)
@@ -346,9 +346,9 @@ describe('checker field access', () => {
 		const source = `type Point
     x: i32
     y: i32
-p: Point =
-    x: 5
-    y: 10
+p:Point
+    x = 5
+    y = 10
 result: i32 = p.x
 panic`
 		const ctx = createContext(source)
@@ -362,8 +362,8 @@ panic`
 	it('reports error for unknown field', () => {
 		const source = `type Point
     x: i32
-p: Point =
-    x: 5
+p:Point
+    x = 5
 result: i32 = p.z
 panic`
 		const ctx = createContext(source)
@@ -391,9 +391,9 @@ panic`
     val: i32
 type Outer
     inner: Inner
-o: Outer =
-    inner:
-        val: 42
+o:Outer
+    inner: Inner
+        val = 42
 result: i32 = o.inner.val
 panic`
 		const ctx = createContext(source)
@@ -410,9 +410,9 @@ describe('SymbolStore record bindings', () => {
 		const source = `type Point
     x: i32
     y: i32
-p: Point =
-    x: 5
-    y: 10
+p:Point
+    x = 5
+    y = 10
 panic`
 		const ctx = createContext(source)
 		tokenize(ctx)
@@ -430,9 +430,9 @@ describe('codegen record types', () => {
 		const source = `type Point
     x: i32
     y: i32
-p: Point =
-    x: 5
-    y: 10
+p:Point
+    x = 5
+    y = 10
 panic`
 		const ctx = createContext(source)
 		tokenize(ctx)
@@ -454,9 +454,9 @@ panic`
 		const source = `type Point
     x: i32
     y: i32
-p: Point =
-    x: 5
-    y: 10
+p:Point
+    x = 5
+    y = 10
 result: i32 = p.x + p.y
 panic`
 		const ctx = createContext(source)
@@ -480,9 +480,9 @@ panic`
 		const source = `type Point
     x: i32
     y: i32
-p: Point =
-    x: 42
-    y: 99
+p:Point
+    x = 42
+    y = 99
 panic`
 		const ctx = createContext(source)
 		tokenize(ctx)
@@ -500,9 +500,9 @@ panic`
 		const source = `type Mixed
     a: i32
     b: i64
-m: Mixed =
-    a: 1
-    b: 2
+m:Mixed
+    a = 1
+    b = 2
 panic`
 		const ctx = createContext(source)
 		tokenize(ctx)
@@ -541,10 +541,10 @@ panic`
     x: i32
 type Line
     len: i32
-p: Point =
-    x: 5
-l: Line =
-    len: 10
+p:Point
+    x = 5
+l:Line
+    len = 10
 sum: i32 = p.x + l.len
 panic`
 		const ctx = createContext(source)
@@ -562,9 +562,9 @@ describe('nested record instantiation parsing', () => {
     val: i32
 type Outer
     inner: Inner
-o: Outer =
+o:Outer
     inner: Inner
-        val: 42
+        val = 42
 panic`
 		const ctx = createContext(source)
 		tokenize(ctx)
@@ -573,9 +573,9 @@ panic`
 	})
 
 	it('creates FieldDecl node for type name in nested record init', () => {
-		const source = `o: Outer =
+		const source = `o:Outer
     inner: Inner
-        val: 42
+        val = 42
 panic`
 		const ctx = createContext(source)
 		tokenize(ctx)
@@ -659,9 +659,9 @@ describe('nested field access', () => {
     val: i32
 type Outer
     inner: Inner
-o: Outer =
+o:Outer
     inner: Inner
-        val: 42
+        val = 42
 result: i32 = o.inner.val
 panic`
 		const ctx = createContext(source)
@@ -677,9 +677,9 @@ panic`
     val: i32
 type Outer
     inner: Inner
-o: Outer =
+o:Outer
     inner: Inner
-        val: 42
+        val = 42
 result: i32 = o.inner.val
 panic`
 		const ctx = createContext(source)
@@ -700,9 +700,9 @@ describe('nested record codegen', () => {
     val: i32
 type Outer
     inner: Inner
-o: Outer =
+o:Outer
     inner: Inner
-        val: 42
+        val = 42
 panic`
 		const ctx = createContext(source)
 		tokenize(ctx)
@@ -722,9 +722,9 @@ describe('nested record instantiation checker', () => {
     val: i32
 type Outer
     inner: Inner
-o: Outer =
+o:Outer
     inner: Inner
-        val: 42
+        val = 42
 panic`
 		const ctx = createContext(source)
 		tokenize(ctx)
@@ -741,9 +741,9 @@ type B
     y: i32
 type Outer
     inner: A
-o: Outer =
+o:Outer
     inner: B
-        y: 5
+        y = 5
 panic`
 		const ctx = createContext(source)
 		tokenize(ctx)
@@ -761,9 +761,9 @@ panic`
     y: i32
 type Outer
     inner: Inner
-o: Outer =
+o:Outer
     inner: Inner
-        x: 1
+        x = 1
 panic`
 		const ctx = createContext(source)
 		tokenize(ctx)
@@ -783,10 +783,10 @@ describe('sibling fields after nested blocks', () => {
 type Outer
     inner: Inner
     x: i32
-o: Outer =
+o:Outer
     inner: Inner
-        val: 42
-    x: 10
+        val = 42
+    x = 10
 panic`
 		const ctx = createContext(source)
 		tokenize(ctx)
@@ -800,10 +800,10 @@ panic`
 type Outer
     inner: Inner
     x: i32
-o: Outer =
+o:Outer
     inner: Inner
-        val: 42
-    x: 10
+        val = 42
+    x = 10
 panic`
 		const ctx = createContext(source)
 		tokenize(ctx)
@@ -831,11 +831,11 @@ type Outer
     inner: Inner
     x: i32
     y: i32
-o: Outer =
+o:Outer
     inner: Inner
-        a: 1
-    x: 2
-    y: 3
+        a = 1
+    x = 2
+    y = 3
 panic`
 		const ctx = createContext(source)
 		tokenize(ctx)
@@ -866,12 +866,12 @@ type L2
 type L1
     l2: L2
     a: i32
-root: L1 =
+root:L1
     l2: L2
         l3: L3
-            val: 100
-        b: 20
-    a: 10
+            val = 100
+        b = 20
+    a = 10
 panic`
 		const ctx = createContext(source)
 		tokenize(ctx)

--- a/packages/compiler/test/semantic-specs.test.ts
+++ b/packages/compiler/test/semantic-specs.test.ts
@@ -173,7 +173,8 @@ test('Semantic Specs', async (t) => {
 			{
 				description: 'nested record init with new syntax',
 				expect: 'valid',
-				input: 'type Inner\n\tval: i32\ntype Outer\n\tinner: Inner\no:Outer\n\tinner: Inner\n\t\tval = 5',
+				input:
+					'type Inner\n\tval: i32\ntype Outer\n\tinner: Inner\no:Outer\n\tinner: Inner\n\t\tval = 5',
 			},
 			{
 				description: 'record field access with new syntax',

--- a/packages/compiler/test/semantic-specs.test.ts
+++ b/packages/compiler/test/semantic-specs.test.ts
@@ -130,40 +130,55 @@ test('Semantic Specs', async (t) => {
 			{
 				description: 'simple record with fields',
 				expect: 'valid',
-				input: 'type Point\n\tx: i32\n\ty: i32\np:Point =\n\tx: 1\n\ty: 2',
+				input: 'type Point\n\tx: i32\n\ty: i32\np:Point\n\tx = 1\n\ty = 2',
 			},
 			{
 				description: 'unknown field in initializer',
 				expect: 'check-error',
-				input: 'type Point\n\tx: i32\np:Point =\n\tx: 1\n\ty: 2',
+				input: 'type Point\n\tx: i32\np:Point\n\tx = 1\n\ty = 2',
 			},
 			{
 				description: 'missing field in initializer',
 				expect: 'check-error',
-				input: 'type Point\n\tx: i32\n\ty: i32\np:Point =\n\tx: 1',
+				input: 'type Point\n\tx: i32\n\ty: i32\np:Point\n\tx = 1',
 			},
 			{
 				description: 'refinement type in field - constraint satisfied',
 				expect: 'valid',
-				input: 'type Point\n\tx: i32<min=0>\n\ty: i32\np:Point =\n\tx: 5\n\ty: 10',
+				input: 'type Point\n\tx: i32<min=0>\n\ty: i32\np:Point\n\tx = 5\n\ty = 10',
 			},
 			{
 				description: 'refinement type in field - constraint violated',
 				errorCode: 'TWCHECK041',
 				expect: 'check-error',
-				input: 'type Point\n\tx: i32<min=0>\n\ty: i32\np:Point =\n\tx: -5\n\ty: 10',
+				input: 'type Point\n\tx: i32<min=0>\n\ty: i32\np:Point\n\tx = -5\n\ty = 10',
 			},
 			{
 				description: 'multiple refinement fields',
 				expect: 'valid',
 				input:
-					'type Bounded\n\ta: i32<min=0, max=100>\n\tb: i32<min=-10>\np:Bounded =\n\ta: 50\n\tb: -5',
+					'type Bounded\n\ta: i32<min=0, max=100>\n\tb: i32<min=-10>\np:Bounded\n\ta = 50\n\tb = -5',
 			},
 			{
 				description: 'refinement field max constraint violated',
 				errorCode: 'TWCHECK041',
 				expect: 'check-error',
-				input: 'type Bounded\n\ta: i32<max=10>\np:Bounded =\n\ta: 100',
+				input: 'type Bounded\n\ta: i32<max=10>\np:Bounded\n\ta = 100',
+			},
+			{
+				description: 'record instantiation with new syntax',
+				expect: 'valid',
+				input: 'type Point\n\tx: i32\n\ty: i32\np:Point\n\tx = 5\n\ty = 10',
+			},
+			{
+				description: 'nested record init with new syntax',
+				expect: 'valid',
+				input: 'type Inner\n\tval: i32\ntype Outer\n\tinner: Inner\no:Outer\n\tinner: Inner\n\t\tval = 5',
+			},
+			{
+				description: 'record field access with new syntax',
+				expect: 'valid',
+				input: 'type Point\n\tx: i32\np:Point\n\tx = 5\nresult:i32 = p.x',
 			},
 		])
 	)
@@ -222,13 +237,13 @@ test('Semantic Specs', async (t) => {
 			{
 				description: 'simple field access',
 				expect: 'valid',
-				input: 'type Point\n\tx: i32\n\ty: i32\np:Point =\n\tx: 1\n\ty: 2\nv:i32 = p.x',
+				input: 'type Point\n\tx: i32\n\ty: i32\np:Point\n\tx = 1\n\ty = 2\nv:i32 = p.x',
 			},
 			{
 				description: 'nested field access',
 				expect: 'valid',
 				input:
-					'type Inner\n\tval: i32\ntype Outer\n\tinner: Inner\no:Outer =\n\tinner: Inner\n\t\tval: 42\nv:i32 = o.inner.val',
+					'type Inner\n\tval: i32\ntype Outer\n\tinner: Inner\no:Outer\n\tinner: Inner\n\t\tval = 42\nv:i32 = o.inner.val',
 			},
 		])
 	)


### PR DESCRIPTION
## Summary
- Change record initialization from `p:Point =` with `x: 50` to `p:Point` with `x = 50`
- Nested record types still use `:` syntax (e.g., `inner: Inner`) since types are PascalCased
- Remove `NestedRecordInit` node kind - use `FieldDecl` with uppercase TypeRef detection instead
- Clean up obvious code comments

## Changes
- **Grammar**: Remove trailing `=` from `RecordBinding`, change `FieldInit` to use `=` instead of `:`
- **Parser**: Remove `emitFieldValue` operation, update semantic actions
- **Checker**: Add `hasUppercaseTypeRef` and `getFieldDeclTypeName` for nested record detection
- **Tests**: Update grammar, semantic, and record type tests

## Test Plan
- [x] All 702 tests pass
- [x] CI passes (build, test, check, typecheck)