### PR TITLE
Feature/rename hints to bounds

### DIFF
--- a/packages/compiler/src/check/type-resolution.ts
+++ b/packages/compiler/src/check/type-resolution.ts
@@ -67,12 +67,13 @@ function extractSizeFromSizeBound(sizeBoundId: NodeId, context: CompilationConte
 }
 
 /**
- * Extract size from a TypeBounds node (new grammar structure).
- * TypeBounds contains Bound children, we find the first one and extract its value.
+ * Extract size from a TypeBounds node.
  * For list types, there should be exactly one bound (the size).
  */
-function extractSizeFromTypeBounds(typeBoundsId: NodeId, context: CompilationContext): number | null {
-	// Find the first Bound child
+function extractSizeFromTypeBounds(
+	typeBoundsId: NodeId,
+	context: CompilationContext
+): number | null {
 	const boundId = findChildByKind(typeBoundsId, NodeKind.Bound, context)
 	if (boundId === null) return null
 
@@ -105,11 +106,10 @@ function resolveListElementType(
 }
 
 function findSizeBoundChild(listTypeId: NodeId, context: CompilationContext): NodeId | null {
-	// First try new grammar structure (TypeBounds)
 	const typeBoundsId = findChildByKind(listTypeId, NodeKind.TypeBounds, context)
 	if (typeBoundsId !== null) return typeBoundsId
 
-	// Fall back to old grammar structure (SizeBound) for compatibility
+	// Fall back to SizeBound for backward compatibility
 	return findChildByKind(listTypeId, NodeKind.SizeBound, context)
 }
 
@@ -120,7 +120,6 @@ function findNestedListTypeChild(listTypeId: NodeId, context: CompilationContext
 function validateListSize(sizeBoundId: NodeId, context: CompilationContext): number | null {
 	const node = context.nodes.get(sizeBoundId)
 
-	// Determine which extraction method to use based on node kind
 	let size: number | null
 	if (node.kind === NodeKind.TypeBounds) {
 		size = extractSizeFromTypeBounds(sizeBoundId, context)

--- a/packages/compiler/src/core/nodes.ts
+++ b/packages/compiler/src/core/nodes.ts
@@ -10,16 +10,14 @@ import type { TokenId } from './tokens.ts'
 export const NodeKind = {
 	BinaryExpr: 104,
 	BindingPattern: 202,
+	Bound: 153,
 	CompareChain: 106,
 	DedentLine: 1,
 
 	FieldAccess: 109,
-
 	FieldDecl: 51,
 	FieldInit: 108,
 	FloatLiteral: 103,
-
-	Hint: 153,
 
 	Identifier: 100,
 	IndentedLine: 0,
@@ -35,16 +33,15 @@ export const NodeKind = {
 	PanicStatement: 10,
 	ParenExpr: 105,
 	PrimitiveBinding: 14,
-
 	Program: 255,
 	RecordBinding: 15,
 	RecordLiteral: 107,
 	RefinementType: 154,
 	RootLine: 2,
-	SizeHint: 152,
+	SizeBound: 152,
 	TypeAnnotation: 150,
+	TypeBounds: 155,
 	TypeDecl: 50,
-	TypeHints: 155,
 	UnaryExpr: 102,
 	VariableBinding: 11,
 

--- a/packages/compiler/src/core/nodes.ts
+++ b/packages/compiler/src/core/nodes.ts
@@ -38,7 +38,6 @@ export const NodeKind = {
 	RecordLiteral: 107,
 	RefinementType: 154,
 	RootLine: 2,
-	SizeBound: 152,
 	TypeAnnotation: 150,
 	TypeBounds: 155,
 	TypeDecl: 50,

--- a/packages/compiler/src/parse/parser.ts
+++ b/packages/compiler/src/parse/parser.ts
@@ -443,20 +443,20 @@ function createNodeEmittingSemantics(
 	})
 
 	semantics.addOperation<NodeId>('emitTypeAnnotation', {
-		Hint(_keyword: Node, _equals: Node, _optMinus: Node, value: Node): NodeId {
+		Bound(_keyword: Node, _equals: Node, _optMinus: Node, value: Node): NodeId {
 			// Store the value token - this allows extracting the numeric value
 			// The keyword type (min/max/size) can be determined from context
-			// (for list size hints, we just need the value)
+			// (for list size bounds, we just need the value)
 			const valueTid = getTokenIdForOhmNode(value)
 			return context.nodes.add({
-				kind: NodeKind.Hint,
+				kind: NodeKind.Bound,
 				subtreeSize: 1,
 				tokenId: valueTid,
 			})
 		},
 		ListType(elementType: Node, suffixes: Node): NodeId {
 			const startCount = context.nodes.count()
-			// Handle hinted primitives as base element type
+			// Handle bounded primitives as base element type
 			if (elementType.ctorName === 'RefinementType') {
 				elementType['emitTypeAnnotation']()
 			}
@@ -473,12 +473,12 @@ function createNodeEmittingSemantics(
 				tokenId: tid,
 			})
 		},
-		ListTypeSuffix(_lbracket: Node, _rbracket: Node, typeHints: Node): NodeId {
-			return typeHints['emitTypeAnnotation']()
+		ListTypeSuffix(_lbracket: Node, _rbracket: Node, typeBounds: Node): NodeId {
+			return typeBounds['emitTypeAnnotation']()
 		},
-		RefinementType(_typeKeyword: Node, typeHints: Node): NodeId {
+		RefinementType(_typeKeyword: Node, typeBounds: Node): NodeId {
 			const startCount = context.nodes.count()
-			typeHints['emitTypeAnnotation']()
+			typeBounds['emitTypeAnnotation']()
 			const childCount = context.nodes.count() - startCount
 
 			const tid = getTokenIdForOhmNode(this)
@@ -500,18 +500,18 @@ function createNodeEmittingSemantics(
 				tokenId: tid,
 			})
 		},
-		TypeHints(_lessThan: Node, hintList: Node, _greaterThan: Node): NodeId {
+		TypeBounds(_lessThan: Node, boundList: Node, _greaterThan: Node): NodeId {
 			const startCount = context.nodes.count()
-			hintList.child(0)['emitTypeAnnotation']()
-			const restHints = hintList.child(2)
-			for (let i = 0; i < restHints.numChildren; i++) {
-				restHints.child(i)['emitTypeAnnotation']()
+			boundList.child(0)['emitTypeAnnotation']()
+			const restBounds = boundList.child(2)
+			for (let i = 0; i < restBounds.numChildren; i++) {
+				restBounds.child(i)['emitTypeAnnotation']()
 			}
 			const childCount = context.nodes.count() - startCount
 
 			const tid = getTokenIdForOhmNode(this)
 			return context.nodes.add({
-				kind: NodeKind.TypeHints,
+				kind: NodeKind.TypeBounds,
 				subtreeSize: 1 + childCount,
 				tokenId: tid,
 			})

--- a/packages/compiler/src/parse/tinywhale.ohm
+++ b/packages/compiler/src/parse/tinywhale.ohm
@@ -49,20 +49,20 @@ TinyWhale {
   TypeRef = ListType | RefinementType | upperIdentifier | typeKeyword
 
   // Refinement type: i32<min=0, max=100>
-  RefinementType = typeKeyword TypeHints
+  RefinementType = typeKeyword TypeBounds
 
-  // Type hints for constraints: <min=0, max=100> or <size=4>
-  TypeHints = lessThan HintList greaterThan
-  HintList = Hint (comma Hint)*
-  Hint = hintKeyword equals minus? intLiteral
-  hintKeyword = minKeyword | maxKeyword | sizeKeyword
+  // Type bounds for constraints: <min=0, max=100> or <size=4>
+  TypeBounds = lessThan BoundList greaterThan
+  BoundList = Bound (comma Bound)*
+  Bound = boundKeyword equals minus? intLiteral
+  boundKeyword = minKeyword | maxKeyword | sizeKeyword
   minKeyword = "min" ~identifierPart
   maxKeyword = "max" ~identifierPart
 
-  // List type with size hint: i32[]<size=4> or nested i32[]<size=4>[]<size=2>
+  // List type with size bound: i32[]<size=4> or nested i32[]<size=4>[]<size=2>
   // Uses iterative suffixes to avoid left recursion
   ListType = ListTypeBase ListTypeSuffix+
-  ListTypeSuffix = lbracket rbracket TypeHints
+  ListTypeSuffix = lbracket rbracket TypeBounds
   ListTypeBase = RefinementType | upperIdentifier | typeKeyword
   sizeKeyword = "size" ~identifierPart
 

--- a/packages/compiler/test/check/type-bounds.test.ts
+++ b/packages/compiler/test/check/type-bounds.test.ts
@@ -9,7 +9,7 @@ import { CompilationContext } from '../../src/core/context.ts'
 import { tokenize } from '../../src/lex/tokenizer.ts'
 import { parse } from '../../src/parse/parser.ts'
 
-describe('check/type-hints TypeStore', () => {
+describe('check/type-bounds TypeStore', () => {
 	it('registerRefinedType creates distinct type from base', () => {
 		const store = new TypeStore()
 		const refinedId = store.registerRefinedType(BuiltinTypeId.I32, { min: 0n })
@@ -82,7 +82,7 @@ function compileAndCheck(source: string): CompilationContext {
 	return ctx
 }
 
-describe('check/type-hints TypeStore properties', () => {
+describe('check/type-bounds TypeStore properties', () => {
 	it('refined types with identical constraints are always interned', () => {
 		fc.assert(
 			fc.property(integerBaseTypeArb, constraintsArb, (baseType, constraints) => {
@@ -167,7 +167,7 @@ describe('check/type-hints TypeStore properties', () => {
 	})
 })
 
-describe('check/type-hints resolution', () => {
+describe('check/type-bounds resolution', () => {
 	it('resolves i32<min=0> to refined type', () => {
 		const ctx = compileAndCheck('x: i32<min=0> = 5\npanic')
 		assert.ok(
@@ -198,8 +198,8 @@ describe('check/type-hints resolution', () => {
 	})
 })
 
-describe('check/type-hints diagnostics', () => {
-	describe('TWCHECK040: invalid hint target', () => {
+describe('check/type-bounds diagnostics', () => {
+	describe('TWCHECK040: invalid bound target', () => {
 		it('errors when applying min/max to f32', () => {
 			const ctx = compileAndCheck('x: f32<min=0> = 5.0\npanic')
 
@@ -264,7 +264,7 @@ describe('check/type-hints diagnostics', () => {
 	})
 })
 
-describe('check/type-hints type compatibility', () => {
+describe('check/type-bounds type compatibility', () => {
 	it('errors when assigning i32 to i32<min=0> without cast', () => {
 		const source = `raw: i32 = 5
 x: i32<min=0> = raw
@@ -314,14 +314,14 @@ function generateRefinedProgram(
 	constraints: { min?: bigint; max?: bigint },
 	value: bigint
 ): string {
-	const hints = []
-	if (constraints.min !== undefined) hints.push(`min=${constraints.min}`)
-	if (constraints.max !== undefined) hints.push(`max=${constraints.max}`)
-	const hintStr = hints.length > 0 ? `<${hints.join(', ')}>` : ''
-	return `x: ${type}${hintStr} = ${value}\npanic\n`
+	const bounds = []
+	if (constraints.min !== undefined) bounds.push(`min=${constraints.min}`)
+	if (constraints.max !== undefined) bounds.push(`max=${constraints.max}`)
+	const boundStr = bounds.length > 0 ? `<${bounds.join(', ')}>` : ''
+	return `x: ${type}${boundStr} = ${value}\npanic\n`
 }
 
-describe('check/type-hints end-to-end properties', () => {
+describe('check/type-bounds end-to-end properties', () => {
 	it('soundness: values within constraints compile without errors', () => {
 		fc.assert(
 			fc.property(

--- a/packages/compiler/test/grammar-specs.test.ts
+++ b/packages/compiler/test/grammar-specs.test.ts
@@ -99,7 +99,7 @@ test('Grammar Specs', async (t) => {
 				'x:i64 = 123', // [FULL]
 				'x:f32 = 1.5', // [FULL]
 				'x:f64 = 2.5', // [FULL]
-				'x:i32<min=0> = 5', // [FULL] - type hints with constraint checking
+				'x:i32<min=0> = 5', // [FULL] - type bounds with constraint checking
 				'x:i32<min=0, max=100> = 50', // [FULL]
 				'arr:i32[]<size=3> = [1, 2, 3]', // [FULL] - single-level list
 				'p:Point', // [FULL] - record binding (new syntax: no trailing =)
@@ -112,7 +112,7 @@ test('Grammar Specs', async (t) => {
 				'x:i64 =', // Missing expression for primitive
 				'x:f32 =', // Missing expression for primitive
 				'x:f64 =', // Missing expression for primitive
-				'x:i32<min=0> =', // Missing expression for hinted primitive
+				'x:i32<min=0> =', // Missing expression for bounded primitive
 				'arr:i32[]<size=3> =', // Missing expression for list type
 				'p:Point = 5', // Expression not allowed for record
 				'p:Point =', // Old syntax: trailing = after record type rejected
@@ -322,7 +322,7 @@ test('Grammar Specs', async (t) => {
 
 		tester.reject(
 			prepareList([
-				'arr:i32[] = [1, 2]', // Missing size hint
+				'arr:i32[] = [1, 2]', // Missing size bound
 			])
 		)
 

--- a/packages/compiler/test/parse/parser.test.ts
+++ b/packages/compiler/test/parse/parser.test.ts
@@ -698,7 +698,7 @@ describe('parse/parser', () => {
 	})
 
 	describe('list type parsing', () => {
-		it('should parse list type with size hint', () => {
+		it('should parse list type with size bound', () => {
 			const source = 'arr: i32[]<size=4> = [1, 2, 3, 4]\npanic'
 			const ctx = new CompilationContext(source)
 			tokenize(ctx)

--- a/packages/compiler/test/semantic-specs.test.ts
+++ b/packages/compiler/test/semantic-specs.test.ts
@@ -100,7 +100,7 @@ test('Semantic Specs', async (t) => {
 	)
 
 	await t.test(
-		'Type Hints',
+		'Type Bounds',
 		semanticTests([
 			{ description: 'min constraint satisfied', expect: 'valid', input: 'x:i32<min=0> = 5' },
 			{ description: 'max constraint satisfied', expect: 'valid', input: 'x:i32<max=100> = 50' },


### PR DESCRIPTION
## Summary

- Renamed all `*Hint*` identifiers to `*Bound*` throughout the compiler package
- "Hints" implied advisory/optional, but these constraints are enforced at compile time
- "Bounds" accurately describes what `min`, `max`, and `size` do

## Changes

- `NodeKind`: `Hint` → `Bound`, `SizeHint` → `SizeBound`, `TypeHints` → `TypeBounds`
- Grammar: `TypeHints` → `TypeBounds`, `HintList` → `BoundList`, `Hint` → `Bound`
- Parser: semantic actions and variables renamed
- type-resolution.ts: all functions and variables renamed
- Test file renamed: `type-hints.test.ts` → `type-bounds.test.ts`
- Removed dead `SizeBound` code (NodeKind existed but was never produced by parser)
- Cleaned up obvious comments

## Test plan

- [x] `mise run ci` passes