### PR TITLE
feat: unify expressions and simplify record syntax

### DIFF
--- a/examples/records/basic.tw
+++ b/examples/records/basic.tw
@@ -1,5 +1,5 @@
 # TinyWhale: Basic record type with field access
-type Point
+Point
     x: i32
     y: i32
 

--- a/examples/records/deeply-nested.tw
+++ b/examples/records/deeply-nested.tw
@@ -1,12 +1,12 @@
 # TinyWhale: Deeply nested records with siblings at each level
-type Level3
+Level3
     value: i32
 
-type Level2
+Level2
     level3: Level3
     b: i32
 
-type Level1
+Level1
     level2: Level2
     a: i32
 

--- a/examples/records/field-init.tw
+++ b/examples/records/field-init.tw
@@ -1,7 +1,7 @@
 # TinyWhale: Record initialization from field access
 # Demonstrates using field access in record initializers
 
-type Point
+Point
     x: i32
     y: i32
 

--- a/examples/records/nested.tw
+++ b/examples/records/nested.tw
@@ -1,8 +1,8 @@
 # TinyWhale: Nested record instantiation with sibling fields
-type Inner
+Inner
     val: i32
 
-type Outer
+Outer
     inner: Inner
     x: i32
 

--- a/packages/compiler/src/check/declarations.ts
+++ b/packages/compiler/src/check/declarations.ts
@@ -12,7 +12,7 @@ import type { DiagnosticCode } from '../core/diagnostics.ts'
 import type { NodeId } from '../core/nodes.ts'
 import { NodeKind } from '../core/nodes.ts'
 import type { Token } from '../core/tokens.ts'
-import { nextTokenId, TokenKind } from '../core/tokens.ts'
+import { TokenKind } from '../core/tokens.ts'
 import type { CheckerState, TypeDeclContext } from './state.ts'
 import { currentBlockContext, popBlockContext, pushBlockContext } from './state.ts'
 import { getTypeNameFromToken, resolveListType, resolveRefinementType } from './type-resolution.ts'
@@ -66,10 +66,8 @@ export function startTypeDecl(
 	context: CompilationContext
 ): void {
 	const typeDeclNode = context.nodes.get(typeDeclId)
-	// TypeDecl node's tokenId points to the 'type' keyword
-	// The type name is in the next token (the identifier)
-	const identTokenId = nextTokenId(typeDeclNode.tokenId)
-	const identToken = context.tokens.get(identTokenId)
+	// TypeDecl node's tokenId points directly to the type name identifier
+	const identToken = context.tokens.get(typeDeclNode.tokenId)
 	const typeName = context.strings.get(identToken.payload as StringId)
 
 	pushBlockContext(state, {

--- a/packages/compiler/src/check/stores.ts
+++ b/packages/compiler/src/check/stores.ts
@@ -46,6 +46,8 @@ export interface FuncInfo {
 	readonly parseNodeId: NodeId
 	/** Body instruction ID (null for forward declarations until defined) */
 	bodyInstId: InstId | null
+	/** All instruction IDs in the body (for expression sequences in multi-line bodies) */
+	bodyInstIds: InstId[]
 	/** Parameter symbols (populated when function is defined) */
 	paramSymbols: SymbolId[]
 	/** Whether the function has been defined (has a body) */
@@ -628,6 +630,7 @@ export class FuncStore {
 		const id = funcId(this.funcs.length)
 		this.funcs.push({
 			bodyInstId: null,
+			bodyInstIds: [],
 			isDefined: false,
 			nameId,
 			paramSymbols: [],
@@ -642,12 +645,18 @@ export class FuncStore {
 	 * Define a function (provide body).
 	 * Must have been declared first via declareForward.
 	 */
-	defineFunc(id: FuncId, bodyInstId: InstId, paramSymbols: SymbolId[]): void {
+	defineFunc(
+		id: FuncId,
+		bodyInstId: InstId,
+		bodyInstIds: InstId[],
+		paramSymbols: SymbolId[]
+	): void {
 		const func = this.funcs[id]
 		if (func === undefined) {
 			throw new Error(`Invalid FuncId: ${id}`)
 		}
 		func.bodyInstId = bodyInstId
+		func.bodyInstIds = bodyInstIds
 		func.paramSymbols = paramSymbols
 		func.isDefined = true
 	}

--- a/packages/compiler/src/core/nodes.ts
+++ b/packages/compiler/src/core/nodes.ts
@@ -19,6 +19,7 @@ export const NodeKind = {
 
 	// Structure (0-9, 255)
 	DedentLine: 1,
+	ExpressionSequence: 116,
 	FieldAccess: 109,
 
 	// Type/Field declarations (50-59)
@@ -54,6 +55,7 @@ export const NodeKind = {
 	RecordLiteral: 107,
 	RefinementType: 154,
 	RootLine: 2,
+	TypeAlias: 18,
 	TypeAnnotation: 150,
 	TypeBounds: 155,
 	TypeDecl: 50,

--- a/packages/compiler/src/lex/tokenizer.ts
+++ b/packages/compiler/src/lex/tokenizer.ts
@@ -183,7 +183,6 @@ const KEYWORDS: Record<string, (typeof TokenKind)[keyof typeof TokenKind]> = {
 	i64: TokenKind.I64,
 	match: TokenKind.Match,
 	panic: TokenKind.Panic,
-	type: TokenKind.Type,
 }
 
 const SIMPLE_OPERATORS: Record<string, TokenKind | undefined> = {

--- a/packages/compiler/src/parse/tinywhale.ohm
+++ b/packages/compiler/src/parse/tinywhale.ohm
@@ -28,10 +28,19 @@ TinyWhale {
   FuncDecl = identifier colon FuncType
 
   // Lambda expression: (x: i32): i32 -> x * 2
+  // LambdaBody can be:
+  //   - Single inline expression: (x: i32): i32 -> x * 2
+  //   - Block with expression sequence:
+  //       (x: i32): i32 ->
+  //           y: i32 = x * 2
+  //           y + 1
   Lambda = lparen ParameterList? rparen (colon TypeRef)? arrow LambdaBody
   ParameterList = Parameter (comma Parameter)*
   Parameter = identifier colon TypeRef
-  LambdaBody = Expression
+  LambdaBody = LambdaBlock | Expression
+  LambdaBlock = newline LambdaBlockLine (newline LambdaBlockLine)*
+  LambdaBlockLine = indentToken anyDedent* BlockExpression
+  BlockExpression = FuncDecl | FuncBinding | PrimitiveBinding | MatchBinding | MatchExpr | Expression
 
   // Function binding: double = (x: i32): i32 -> x * 2
   FuncBinding = identifier equals Lambda

--- a/packages/compiler/src/parse/tinywhale.ohm
+++ b/packages/compiler/src/parse/tinywhale.ohm
@@ -21,7 +21,7 @@ TinyWhale {
   DedentLine = anyDedent+ Statement?
 
   // Statements
-  Statement = TypeDecl | MatchBinding | MatchExpr | FuncDecl | FuncBinding | PrimitiveBinding | RecordBinding | PanicStatement
+  Statement = TypeDecl | TypeAlias | MatchBinding | MatchExpr | FuncDecl | FuncBinding | PrimitiveBinding | RecordBinding | PanicStatement
   PanicStatement = panic
 
   // Function forward declaration: factorial: (i32) -> i32
@@ -38,6 +38,9 @@ TinyWhale {
 
   // Type declaration: type Point
   TypeDecl = typeKeywordToken upperIdentifier
+
+  // Type alias (no `type` keyword): Add = (i32, i32) -> i32
+  TypeAlias = upperIdentifier equals TypeRef
 
   // Primitive type reference (types that require inline expression)
   PrimitiveTypeRef = ListType | RefinementType | typeKeyword

--- a/packages/compiler/src/parse/tinywhale.ohm
+++ b/packages/compiler/src/parse/tinywhale.ohm
@@ -21,7 +21,7 @@ TinyWhale {
   DedentLine = anyDedent+ Statement?
 
   // Statements
-  Statement = TypeDecl | TypeAlias | MatchBinding | MatchExpr | FuncDecl | FuncBinding | PrimitiveBinding | RecordBinding | PanicStatement
+  Statement = RecordTypeDecl | TypeAlias | MatchBinding | MatchExpr | FuncDecl | FuncBinding | PrimitiveBinding | RecordBinding | PanicStatement
   PanicStatement = panic
 
   // Function forward declaration: factorial: (i32) -> i32
@@ -43,10 +43,12 @@ TinyWhale {
   BlockExpression = FuncDecl | FuncBinding | PrimitiveBinding | MatchBinding | MatchExpr | Expression
 
   // Function binding: double = (x: i32): i32 -> x * 2
-  FuncBinding = identifier equals Lambda
+  // With optional type annotation: add: Add = (a: i32, b: i32): i32 -> a + b
+  FuncBinding = identifier (colon TypeRef)? equals Lambda
 
-  // Type declaration: type Point
-  TypeDecl = typeKeywordToken upperIdentifier
+  // Record type declaration: Point (followed by indented FieldDecls)
+  // Use negative lookahead to avoid matching TypeAlias (= TypeRef) or bindings (: Type)
+  RecordTypeDecl = upperIdentifier ~(equals | colon)
 
   // Type alias (no `type` keyword): Add = (i32, i32) -> i32
   TypeAlias = upperIdentifier equals TypeRef
@@ -161,11 +163,10 @@ TinyWhale {
   unaryOp = minus | tilde
 
   // Keywords
-  keyword = panic | typeKeyword | matchKeyword | typeKeywordToken
+  keyword = panic | typeKeyword | matchKeyword
   typeKeyword = i32 | i64 | f32 | f64
   panic = "panic" ~identifierPart
   matchKeyword = "match" ~identifierPart
-  typeKeywordToken = "type" ~identifierPart
   i32 = "i32" ~identifierPart
   i64 = "i64" ~identifierPart
   f32 = "f32" ~identifierPart

--- a/packages/compiler/test/check/checker.test.ts
+++ b/packages/compiler/test/check/checker.test.ts
@@ -29,8 +29,8 @@ describe('check/checker', () => {
 
 			assert.strictEqual(result.succeeded, false)
 			const errors = getErrors(ctx)
-			// Errors for: IndentedLine (line 2) and DedentLine (from EOF dedent)
-			assert.strictEqual(errors.length, 2)
+			// Error for IndentedLine (line 2) - DedentLine from EOF is processed normally
+			assert.strictEqual(errors.length, 1)
 			assert.ok(errors[0]?.message.includes('unexpected indentation'))
 		})
 
@@ -41,8 +41,9 @@ describe('check/checker', () => {
 
 			assert.strictEqual(result.succeeded, false)
 			const errors = getErrors(ctx)
-			// IndentedLine and DedentLine both produce errors
-			assert.ok(errors.length >= 2)
+			// Only IndentedLine produces error - DedentLine is processed as a root statement
+			assert.strictEqual(errors.length, 1)
+			assert.ok(errors[0]?.message.includes('unexpected indentation'))
 		})
 
 		it('should accept root-level statements', () => {

--- a/packages/compiler/test/check/expression-unification.test.ts
+++ b/packages/compiler/test/check/expression-unification.test.ts
@@ -1,0 +1,169 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import fc from 'fast-check'
+
+import { check } from '../../src/check/checker.ts'
+import { CompilationContext } from '../../src/core/context.ts'
+import { compile } from '../../src/index.ts'
+import { tokenize } from '../../src/lex/tokenizer.ts'
+import { parse } from '../../src/parse/parser.ts'
+
+function compileAndCheck(source: string): CompilationContext {
+	const ctx = new CompilationContext(source)
+	tokenize(ctx)
+	parse(ctx)
+	check(ctx)
+	return ctx
+}
+
+describe('check/expression unification', () => {
+	describe('type aliases without type keyword', () => {
+		it('should parse type alias at grammar level', () => {
+			// Type alias definition parses correctly
+			const source = `Add = (i32, i32) -> i32
+panic`
+			const ctx = new CompilationContext(source)
+			tokenize(ctx)
+			const parseResult = parse(ctx)
+			assert.ok(parseResult.succeeded, 'Parsing should succeed')
+		})
+
+		it('should handle type alias in checker', () => {
+			// Type alias should be recognized by checker (creates a type)
+			const source = `Add = (i32, i32) -> i32
+panic`
+			const ctx = compileAndCheck(source)
+			assert.ok(!ctx.hasErrors(), `Errors: ${ctx.getDiagnostics().map((d) => d.message)}`)
+		})
+
+		it('resolves type alias in function binding', () => {
+			// Type alias used as type annotation on function binding
+			const source = `Add = (i32, i32) -> i32
+add: Add = (a: i32, b: i32): i32 -> a + b
+panic`
+			const ctx = compileAndCheck(source)
+			assert.ok(!ctx.hasErrors(), `Errors: ${ctx.getDiagnostics().map((d) => d.message)}`)
+		})
+	})
+
+	describe('expression sequences in lambda bodies', () => {
+		it('should compile multi-line function body', () => {
+			const source = `f = (x: i32): i32 ->
+\ty: i32 = x * 2
+\ty + 1
+result: i32 = f(5)
+panic`
+			const ctx = compileAndCheck(source)
+			assert.ok(!ctx.hasErrors(), `Errors: ${ctx.getDiagnostics().map((d) => d.message)}`)
+		})
+
+		it('should return type of last expression in sequence', () => {
+			const source = `f = (x: i32): i32 ->
+\ty: i32 = x * 2
+\ty + 1
+panic`
+			const ctx = compileAndCheck(source)
+			assert.ok(!ctx.hasErrors(), `Errors: ${ctx.getDiagnostics().map((d) => d.message)}`)
+		})
+
+		it('should allow nested function definitions', () => {
+			const source = `compute = (x: i32): i32 ->
+\thelper: (i32) -> i32
+\thelper = (n: i32): i32 -> n * 2
+\thelper(x)
+panic`
+			const ctx = compileAndCheck(source)
+			assert.ok(!ctx.hasErrors(), `Errors: ${ctx.getDiagnostics().map((d) => d.message)}`)
+		})
+
+		it('should type-check return type against last expression', () => {
+			const source = `f = (x: i32): i64 ->
+\ty: i32 = x * 2
+\ty + 1
+panic`
+			const ctx = compileAndCheck(source)
+			// Should error: return type is i64 but last expression is i32
+			assert.ok(ctx.hasErrors())
+		})
+	})
+
+	describe('codegen for expression sequences', () => {
+		it('should generate valid WASM for multi-line function body', () => {
+			const source = `f = (x: i32): i32 ->
+\ty: i32 = x * 2
+\ty + 1
+result: i32 = f(5)
+panic`
+			const result = compile(source)
+			assert.strictEqual(
+				result.valid,
+				true,
+				`Warnings: ${result.warnings.map((w) => w.message).join(', ')}`
+			)
+		})
+
+		it('should execute multi-line function correctly', async () => {
+			const source = `f = (x: i32): i32 ->
+\ty: i32 = x * 2
+\ty + 1
+result: i32 = f(5)
+panic`
+			const result = compile(source)
+			assert.strictEqual(result.valid, true)
+			// f(5) should compute: y = 5 * 2 = 10, then y + 1 = 11
+		})
+	})
+
+	describe('property tests', () => {
+		it('all i32 bindings compile without errors', () => {
+			fc.assert(
+				fc.property(fc.integer({ max: 1000, min: -1000 }), (value) => {
+					const source = `x: i32 = ${value}\npanic`
+					const ctx = compileAndCheck(source)
+					return !ctx.hasErrors()
+				}),
+				{ numRuns: 50 }
+			)
+		})
+
+		it('all i64 bindings compile without errors', () => {
+			fc.assert(
+				fc.property(fc.integer({ max: 1000, min: -1000 }), (value) => {
+					const source = `x: i64 = ${value}\npanic`
+					const ctx = compileAndCheck(source)
+					return !ctx.hasErrors()
+				}),
+				{ numRuns: 50 }
+			)
+		})
+
+		it('multi-line function bodies compile for various expressions', () => {
+			fc.assert(
+				fc.property(fc.integer({ max: 100, min: 1 }), fc.integer({ max: 100, min: 1 }), (a, b) => {
+					const source = `f = (x: i32): i32 ->
+\ty: i32 = x * ${a}
+\ty + ${b}
+panic`
+					const ctx = compileAndCheck(source)
+					return !ctx.hasErrors()
+				}),
+				{ numRuns: 30 }
+			)
+		})
+
+		it('nested function definitions compile', () => {
+			fc.assert(
+				fc.property(fc.integer({ max: 10, min: 1 }), (multiplier) => {
+					const source = `outer = (x: i32): i32 ->
+\tinner: (i32) -> i32
+\tinner = (n: i32): i32 -> n * ${multiplier}
+\tinner(x)
+panic`
+					const ctx = compileAndCheck(source)
+					return !ctx.hasErrors()
+				}),
+				{ numRuns: 20 }
+			)
+		})
+	})
+})

--- a/packages/compiler/test/check/list-types.test.ts
+++ b/packages/compiler/test/check/list-types.test.ts
@@ -94,7 +94,7 @@ panic`
 			})
 
 			it('errors when indexing a record', () => {
-				const source = `type Point
+				const source = `Point
     x: i32
     y: i32
 p: Point =
@@ -133,7 +133,7 @@ panic`
 
 	describe('list type field declaration in records', () => {
 		it('parses record type with list field', () => {
-			const source = `type Data
+			const source = `Data
     items: i32[]<size=3>
 panic`
 			const ctx = createContext(source)
@@ -144,7 +144,7 @@ panic`
 		})
 
 		it('checks record type with list field - type registered', () => {
-			const source = `type Data
+			const source = `Data
     items: i32[]<size=3>
 panic`
 			const ctx = prepareAndCheck(source)
@@ -161,7 +161,7 @@ panic`
 
 	describe('future: list in record field initialization', () => {
 		it('documents expected: list field init in record should work', () => {
-			const source = `type Data
+			const source = `Data
     items: i32[]<size=1>
 d:Data
     items = [99]

--- a/packages/compiler/test/grammar-specs.test.ts
+++ b/packages/compiler/test/grammar-specs.test.ts
@@ -516,6 +516,37 @@ test('Grammar Specs', async (t) => {
 		}
 	})
 
+	await t.test('Expression Sequences in Lambda Bodies', (t) => {
+		const tester = createTester(grammar, 'Expression Sequences', 'Program')
+
+		tester.match(
+			prepareList([
+				// Multi-line function body with binding then expression
+				`f = (x: i32): i32 ->
+    y: i32 = x * 2
+    y + 1
+panic`,
+				// Nested function definition inside lambda body
+				`compute = (x: i32): i32 ->
+    helper: (i32) -> i32
+    helper = (n: i32): i32 -> n * 2
+    helper(x)
+panic`,
+			])
+		)
+
+		const result = tester.run()
+		if (result.failed > 0) {
+			for (const r of result.results) {
+				if (!r.passed) {
+					t.diagnostic(`[FAILED] ${r.expected} '${r.input}': ${r.errorMessage}`)
+					t.diagnostic(`Prepared Input: ${JSON.stringify(r.input)}`)
+				}
+			}
+			assert.fail(`Failed ${result.failed} grammar tests`)
+		}
+	})
+
 	await t.test('Type Aliases', (t) => {
 		const tester = createTester(grammar, 'Type Aliases', 'Program')
 

--- a/packages/compiler/test/grammar-specs.test.ts
+++ b/packages/compiler/test/grammar-specs.test.ts
@@ -59,8 +59,8 @@ test('Grammar Specs', async (t) => {
 				'panic # comment', // [FULL]
 				'x:i32 = 1', // [FULL]
 				'x:i32 = 1 + 2', // [FULL]
-				'type Point\n\tx: i32', // [FULL] - single field record
-				'type Point\n\tx: i32\n\ty: i32', // [FULL] - multi-field record
+				'Point\n\tx: i32', // [FULL] - single field record
+				'Point\n\tx: i32\n\ty: i32', // [FULL] - multi-field record
 			])
 		)
 
@@ -131,15 +131,15 @@ test('Grammar Specs', async (t) => {
 		}
 	})
 
-	await t.test('Type Declarations', (t) => {
-		const tester = createTester(grammar, 'Type Declarations', 'TypeDecl')
+	await t.test('Record Type Declarations', (t) => {
+		const tester = createTester(grammar, 'Record Type Declarations', 'RecordTypeDecl')
 
-		tester.match(prepareList(['type Point', 'type MyType']))
+		tester.match(prepareList(['Point', 'MyType']))
 
 		tester.reject(
 			prepareList([
-				'type lowerCase', // Must be upper
-				'type', // Missing name
+				'lowerCase', // Must start with uppercase
+				'123Type', // Must start with letter
 			])
 		)
 
@@ -402,24 +402,24 @@ test('Grammar Specs', async (t) => {
 		tester.match(
 			prepareList([
 				// Simple record with fields
-				'type Point\n\tx: i32\n\ty: i32\np:Point\n\tx = 1\n\ty = 2',
+				'Point\n\tx: i32\n\ty: i32\np:Point\n\tx = 1\n\ty = 2',
 				// Record with list field
-				'type Foo\n\titems: i32[]<size=3>\nf:Foo\n\titems = [1, 2, 3]',
+				'Foo\n\titems: i32[]<size=3>\nf:Foo\n\titems = [1, 2, 3]',
 				// Nested record initialization
-				'type Inner\n\tvalue: i32\ntype Outer\n\tinner: Inner\no:Outer\n\tinner: Inner\n\t\tvalue = 42',
+				'Inner\n\tvalue: i32\nOuter\n\tinner: Inner\no:Outer\n\tinner: Inner\n\t\tvalue = 42',
 				// Additional new syntax tests
-				'type Point\n\tx: i32\np:Point\n\tx = 5', // no = after type, = for field value
-				'type Point\n\tx: i32\n\ty: i32\np:Point\n\tx = 5\n\ty = 10', // Multiple fields
-				'type Inner\n\tval: i32\ntype Outer\n\tinner: Inner\no:Outer\n\tinner: Inner\n\t\tval = 5', // Nested
+				'Point\n\tx: i32\np:Point\n\tx = 5', // no = after type, = for field value
+				'Point\n\tx: i32\n\ty: i32\np:Point\n\tx = 5\n\ty = 10', // Multiple fields
+				'Inner\n\tval: i32\nOuter\n\tinner: Inner\no:Outer\n\tinner: Inner\n\t\tval = 5', // Nested
 			])
 		)
 
 		// Old syntax should be rejected
 		tester.reject(
 			prepareList([
-				'type Point\n\tx: i32\np:Point =\n\tx = 5', // Old syntax: = after type name rejected
-				'type Point\n\tx: i32\np:Point\n\tx: 5', // Old syntax: : for values rejected
-				'type Point\n\tx: i32\np:Point =\n\tx: 5', // Old syntax: both = after type and : for value
+				'Point\n\tx: i32\np:Point =\n\tx = 5', // Old syntax: = after type name rejected
+				'Point\n\tx: i32\np:Point\n\tx: 5', // Old syntax: : for values rejected
+				'Point\n\tx: i32\np:Point =\n\tx: 5', // Old syntax: both = after type and : for value
 			])
 		)
 

--- a/packages/compiler/test/grammar-specs.test.ts
+++ b/packages/compiler/test/grammar-specs.test.ts
@@ -516,6 +516,36 @@ test('Grammar Specs', async (t) => {
 		}
 	})
 
+	await t.test('Type Aliases', (t) => {
+		const tester = createTester(grammar, 'Type Aliases', 'Program')
+
+		tester.match(
+			prepareList([
+				// [GRAMMAR] Type alias without type keyword (PascalCase = TypeRef)
+				'Add = (i32, i32) -> i32\npanic',
+				'Percentage = i32\npanic', // Simple type alias
+				'IntList = i32[]<size=4>\npanic', // List type alias
+			])
+		)
+
+		tester.reject(
+			prepareList([
+				'add = (i32, i32) -> i32\npanic', // lowercase not a type alias (but valid func binding with lambda)
+			])
+		)
+
+		const result = tester.run()
+		if (result.failed > 0) {
+			for (const r of result.results) {
+				if (!r.passed) {
+					t.diagnostic(`[FAILED] ${r.expected} '${r.input}': ${r.errorMessage}`)
+					t.diagnostic(`Prepared Input: ${JSON.stringify(r.input)}`)
+				}
+			}
+			assert.fail(`Failed ${result.failed} grammar tests`)
+		}
+	})
+
 	await t.test('Identifiers', (t) => {
 		const tester = createTester(grammar, 'Identifiers', 'Program')
 

--- a/packages/compiler/test/parse/parser.test.ts
+++ b/packages/compiler/test/parse/parser.test.ts
@@ -1,7 +1,8 @@
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { CompilationContext } from '../../src/core/context.ts'
-import { type NodeId, NodeKind } from '../../src/core/nodes.ts'
+import type { NodeId } from '../../src/core/nodes.ts'
+import { NodeKind } from '../../src/core/nodes.ts'
 import { tokenize } from '../../src/lex/tokenizer.ts'
 import { matchOnly, parse } from '../../src/parse/parser.ts'
 
@@ -809,7 +810,7 @@ describe('parse/parser', () => {
 
 	describe('list in record type parsing', () => {
 		it('should parse record type with list field', () => {
-			const source = `type Foo
+			const source = `Foo
     items: i32[]<size=3>
 panic`
 			const ctx = new CompilationContext(source)
@@ -819,7 +820,7 @@ panic`
 		})
 
 		it('should parse record type with multiple list fields', () => {
-			const source = `type Data
+			const source = `Data
     xs: i32[]<size=4>
     ys: f64[]<size=4>
 panic`
@@ -830,7 +831,7 @@ panic`
 		})
 
 		it('should parse record type with nested list field', () => {
-			const source = `type Matrix
+			const source = `Matrix
     data: i32[]<size=3>[]<size=3>
 panic`
 			const ctx = new CompilationContext(source)
@@ -842,7 +843,7 @@ panic`
 
 	describe('list literal in record init parsing', () => {
 		it('should parse record initialization with list field', () => {
-			const source = `type Foo
+			const source = `Foo
     items: i32[]<size=3>
 f:Foo
     items = [1, 2, 3]
@@ -854,7 +855,7 @@ panic`
 		})
 
 		it('should parse record initialization with nested list field', () => {
-			const source = `type Matrix
+			const source = `Matrix
     data: i32[]<size=2>[]<size=2>
 m:Matrix
     data = [[1, 2], [3, 4]]
@@ -866,7 +867,7 @@ panic`
 		})
 
 		it('should parse record initialization with multiple list fields', () => {
-			const source = `type Data
+			const source = `Data
     xs: i32[]<size=2>
     ys: i32[]<size=2>
 d:Data

--- a/packages/compiler/test/record-types.property.test.ts
+++ b/packages/compiler/test/record-types.property.test.ts
@@ -71,7 +71,7 @@ function generateTypeDecl(def: {
 	fields: { name: string; type: string }[]
 }): string {
 	const fieldLines = def.fields.map((f) => `    ${f.name}: ${f.type}`).join('\n')
-	return `type ${def.typeName}\n${fieldLines}`
+	return `${def.typeName}\n${fieldLines}`
 }
 
 /** Generate TinyWhale source for a record instantiation */
@@ -618,10 +618,9 @@ describe('record types/multiple type declarations properties', () => {
 	it('N type declarations creates N registered types', () => {
 		fc.assert(
 			fc.property(fc.integer({ max: 5, min: 1 }), (typeCount) => {
-				const typeDecls = Array.from(
-					{ length: typeCount },
-					(_, i) => `type T${i}\n    f: i32`
-				).join('\n')
+				const typeDecls = Array.from({ length: typeCount }, (_, i) => `T${i}\n    f: i32`).join(
+					'\n'
+				)
 				const source = `${typeDecls}\npanic\n`
 
 				const ctx = new CompilationContext(source)
@@ -651,9 +650,9 @@ function generateNestedTypes(depth: number): string {
 	let types = ''
 	for (let i = depth - 1; i >= 0; i--) {
 		if (i === depth - 1) {
-			types += `type T${i}\n    val: i32\n`
+			types += `T${i}\n    val: i32\n`
 		} else {
-			types += `type T${i}\n    inner: T${i + 1}\n`
+			types += `T${i}\n    inner: T${i + 1}\n`
 		}
 	}
 	return types
@@ -685,10 +684,10 @@ function generateNestedTypesWithSiblings(depth: number): string {
 	for (let i = depth - 1; i >= 0; i--) {
 		if (i === depth - 1) {
 			// Leaf type: just a primitive
-			types += `type T${i}\n    val: i32\n`
+			types += `T${i}\n    val: i32\n`
 		} else {
 			// Non-leaf: inner record + sibling primitive
-			types += `type T${i}\n    inner: T${i + 1}\n    sib${i}: i32\n`
+			types += `T${i}\n    inner: T${i + 1}\n    sib${i}: i32\n`
 		}
 	}
 	return types
@@ -832,7 +831,7 @@ describe('record types/sibling fields after nested blocks properties', () => {
 				fc.integer({ max: 100, min: 0 }),
 				fc.integer({ max: 100, min: 0 }),
 				(siblingFirst, innerVal, sibVal) => {
-					const types = `type Inner\n    val: i32\ntype Outer\n    inner: Inner\n    sib: i32\n`
+					const types = `Inner\n    val: i32\nOuter\n    inner: Inner\n    sib: i32\n`
 
 					// Two orderings of fields in init
 					const init = siblingFirst
@@ -908,7 +907,7 @@ describe('record types/sibling fields after nested blocks properties', () => {
 					for (let i = 0; i < siblingCount; i++) {
 						typeFields += `    s${i}: i32\n`
 					}
-					const types = `type Inner\n    val: i32\ntype Outer\n${typeFields}`
+					const types = `Inner\n    val: i32\nOuter\n${typeFields}`
 
 					// Init with nested block first, then all siblings
 					let init = `o:Outer\n    inner: Inner\n        val = ${values[0] ?? 0}\n`

--- a/packages/compiler/test/record-types.test.ts
+++ b/packages/compiler/test/record-types.test.ts
@@ -64,12 +64,12 @@ describe('TypeStore record types', () => {
 })
 
 describe('record types tokenization', () => {
-	it('tokenizes type keyword', () => {
-		const ctx = new CompilationContext('type Point')
+	it('tokenizes uppercase identifier as type name', () => {
+		const ctx = new CompilationContext('Point')
 		tokenize(ctx)
 		const tokens = [...ctx.tokens]
-		const typeToken = tokens.find(([, t]) => t.kind === TokenKind.Type)
-		assert.ok(typeToken, 'should have Type token')
+		const identToken = tokens.find(([, t]) => t.kind === TokenKind.Identifier)
+		assert.ok(identToken, 'should have Identifier token for type name')
 	})
 })
 
@@ -93,7 +93,7 @@ describe('record types node kinds', () => {
 
 describe('record types parsing', () => {
 	it('parses type declaration', () => {
-		const source = `type Point
+		const source = `Point
     x: i32
     y: i32
 panic`
@@ -106,7 +106,7 @@ panic`
 
 describe('record literal parsing', () => {
 	it('parses record instantiation', () => {
-		const source = `type Point
+		const source = `Point
     x: i32
     y: i32
 p:Point
@@ -143,7 +143,7 @@ panic`
 describe('parser semantic actions', () => {
 	it('creates TypeDecl node', () => {
 		// Use simple source without field declarations (FieldDecl semantic action comes in a later task)
-		const source = `type Point
+		const source = `Point
 panic`
 		const ctx = new CompilationContext(source)
 		tokenize(ctx)
@@ -155,7 +155,7 @@ panic`
 	})
 
 	it('creates FieldDecl nodes', () => {
-		const source = `type Point
+		const source = `Point
     x: i32
     y: i32
 panic`
@@ -197,7 +197,7 @@ panic`
 
 describe('checker type declarations', () => {
 	it('registers type in TypeStore', () => {
-		const source = `type Point
+		const source = `Point
     x: i32
     y: i32
 panic`
@@ -212,7 +212,7 @@ panic`
 	})
 
 	it('reports error for duplicate field names', () => {
-		const source = `type Point
+		const source = `Point
     x: i32
     x: i32
 panic`
@@ -225,7 +225,7 @@ panic`
 	})
 
 	it('registers fields with correct types', () => {
-		const source = `type Point
+		const source = `Point
     x: i32
     y: i64
 panic`
@@ -245,7 +245,7 @@ panic`
 	})
 
 	it('handles type with no fields', () => {
-		const source = `type Empty
+		const source = `Empty
 panic`
 		const ctx = new CompilationContext(source)
 		tokenize(ctx)
@@ -265,7 +265,7 @@ function createContext(source: string): CompilationContext {
 
 describe('checker record instantiation', () => {
 	it('validates all fields provided', () => {
-		const source = `type Point
+		const source = `Point
     x: i32
     y: i32
 p:Point
@@ -281,7 +281,7 @@ panic`
 	})
 
 	it('reports error for missing field', () => {
-		const source = `type Point
+		const source = `Point
     x: i32
     y: i32
 p:Point
@@ -296,7 +296,7 @@ panic`
 	})
 
 	it('reports error for unknown field', () => {
-		const source = `type Point
+		const source = `Point
     x: i32
     y: i32
 p:Point
@@ -313,7 +313,7 @@ panic`
 	})
 
 	it('reports error for duplicate field in initializer', () => {
-		const source = `type Point
+		const source = `Point
     x: i32
     y: i32
 p:Point
@@ -343,7 +343,7 @@ panic`
 
 describe('checker field access', () => {
 	it('resolves field type', () => {
-		const source = `type Point
+		const source = `Point
     x: i32
     y: i32
 p:Point
@@ -360,7 +360,7 @@ panic`
 	})
 
 	it('reports error for unknown field', () => {
-		const source = `type Point
+		const source = `Point
     x: i32
 p:Point
     x = 5
@@ -387,9 +387,9 @@ panic`
 	})
 
 	it('handles nested field access', () => {
-		const source = `type Inner
+		const source = `Inner
     val: i32
-type Outer
+Outer
     inner: Inner
 o:Outer
     inner: Inner
@@ -407,7 +407,7 @@ panic`
 describe('SymbolStore record bindings', () => {
 	it('creates flattened locals for record fields', () => {
 		// When binding p: Point, should create $p_x and $p_y locals
-		const source = `type Point
+		const source = `Point
     x: i32
     y: i32
 p:Point
@@ -427,7 +427,7 @@ panic`
 
 describe('codegen record types', () => {
 	it('emits flattened locals', () => {
-		const source = `type Point
+		const source = `Point
     x: i32
     y: i32
 p:Point
@@ -451,7 +451,7 @@ panic`
 	})
 
 	it('emits field access as local.get', () => {
-		const source = `type Point
+		const source = `Point
     x: i32
     y: i32
 p:Point
@@ -477,7 +477,7 @@ panic`
 	})
 
 	it('emits local.set for each record field initializer', () => {
-		const source = `type Point
+		const source = `Point
     x: i32
     y: i32
 p:Point
@@ -497,7 +497,7 @@ panic`
 	})
 
 	it('emits correct types for mixed-type record fields', () => {
-		const source = `type Mixed
+		const source = `Mixed
     a: i32
     b: i64
 m:Mixed
@@ -519,10 +519,10 @@ panic`
 
 describe('multiple type declarations', () => {
 	it('supports multiple type declarations in one file', () => {
-		const source = `type Point
+		const source = `Point
     x: i32
     y: i32
-type Line
+Line
     start: i32
     end: i32
 panic`
@@ -537,9 +537,9 @@ panic`
 	})
 
 	it('allows using fields from both types', () => {
-		const source = `type Point
+		const source = `Point
     x: i32
-type Line
+Line
     len: i32
 p:Point
     x = 5
@@ -558,9 +558,9 @@ panic`
 
 describe('nested record instantiation parsing', () => {
 	it('parses nested record init syntax', () => {
-		const source = `type Inner
+		const source = `Inner
     val: i32
-type Outer
+Outer
     inner: Inner
 o:Outer
     inner: Inner
@@ -589,9 +589,9 @@ panic`
 
 describe('nested record types', () => {
 	it('supports field with user-defined type', () => {
-		const source = `type Inner
+		const source = `Inner
     val: i32
-type Outer
+Outer
     inner: Inner
 panic`
 		const ctx = createContext(source)
@@ -608,7 +608,7 @@ panic`
 	})
 
 	it('errors when referencing undefined type', () => {
-		const source = `type Outer
+		const source = `Outer
     inner: Nonexistent
 panic`
 		const ctx = createContext(source)
@@ -620,9 +620,9 @@ panic`
 	})
 
 	it('errors on forward reference (define-before-use)', () => {
-		const source = `type Outer
+		const source = `Outer
     inner: Inner
-type Inner
+Inner
     val: i32
 panic`
 		const ctx = createContext(source)
@@ -635,7 +635,7 @@ panic`
 
 	describe('recursive type detection', () => {
 		it('detects direct self-reference cycle', () => {
-			const source = `type Node
+			const source = `Node
     next: Node
 panic`
 			const ctx = createContext(source)
@@ -655,9 +655,9 @@ panic`
 
 describe('nested field access', () => {
 	it('supports nested field access (o.inner.val)', () => {
-		const source = `type Inner
+		const source = `Inner
     val: i32
-type Outer
+Outer
     inner: Inner
 o:Outer
     inner: Inner
@@ -673,9 +673,9 @@ panic`
 	})
 
 	it('emits correct code for nested field access', () => {
-		const source = `type Inner
+		const source = `Inner
     val: i32
-type Outer
+Outer
     inner: Inner
 o:Outer
     inner: Inner
@@ -696,9 +696,9 @@ panic`
 
 describe('nested record codegen', () => {
 	it('emits correct flattened locals for nested records', () => {
-		const source = `type Inner
+		const source = `Inner
     val: i32
-type Outer
+Outer
     inner: Inner
 o:Outer
     inner: Inner
@@ -718,9 +718,9 @@ panic`
 
 describe('nested record instantiation checker', () => {
 	it('validates nested record init type name', () => {
-		const source = `type Inner
+		const source = `Inner
     val: i32
-type Outer
+Outer
     inner: Inner
 o:Outer
     inner: Inner
@@ -735,11 +735,11 @@ panic`
 	})
 
 	it('errors on type mismatch in nested init', () => {
-		const source = `type A
+		const source = `A
     x: i32
-type B
+B
     y: i32
-type Outer
+Outer
     inner: A
 o:Outer
     inner: B
@@ -756,10 +756,10 @@ panic`
 	})
 
 	it('validates all nested fields provided', () => {
-		const source = `type Inner
+		const source = `Inner
     x: i32
     y: i32
-type Outer
+Outer
     inner: Inner
 o:Outer
     inner: Inner
@@ -778,9 +778,9 @@ panic`
 
 describe('sibling fields after nested blocks', () => {
 	it('parses sibling field after nested record block', () => {
-		const source = `type Inner
+		const source = `Inner
     val: i32
-type Outer
+Outer
     inner: Inner
     x: i32
 o:Outer
@@ -795,9 +795,9 @@ panic`
 	})
 
 	it('compiles sibling field after nested block', () => {
-		const source = `type Inner
+		const source = `Inner
     val: i32
-type Outer
+Outer
     inner: Inner
     x: i32
 o:Outer
@@ -825,9 +825,9 @@ panic`
 	})
 
 	it('compiles multiple siblings after nested block', () => {
-		const source = `type Inner
+		const source = `Inner
     a: i32
-type Outer
+Outer
     inner: Inner
     x: i32
     y: i32
@@ -858,12 +858,12 @@ panic`
 	})
 
 	it('compiles deeply nested with siblings at each level', () => {
-		const source = `type L3
+		const source = `L3
     val: i32
-type L2
+L2
     l3: L3
     b: i32
-type L1
+L1
     l2: L2
     a: i32
 root:L1

--- a/packages/compiler/test/semantic-specs.test.ts
+++ b/packages/compiler/test/semantic-specs.test.ts
@@ -130,56 +130,55 @@ test('Semantic Specs', async (t) => {
 			{
 				description: 'simple record with fields',
 				expect: 'valid',
-				input: 'type Point\n\tx: i32\n\ty: i32\np:Point\n\tx = 1\n\ty = 2',
+				input: 'Point\n\tx: i32\n\ty: i32\np:Point\n\tx = 1\n\ty = 2',
 			},
 			{
 				description: 'unknown field in initializer',
 				expect: 'check-error',
-				input: 'type Point\n\tx: i32\np:Point\n\tx = 1\n\ty = 2',
+				input: 'Point\n\tx: i32\np:Point\n\tx = 1\n\ty = 2',
 			},
 			{
 				description: 'missing field in initializer',
 				expect: 'check-error',
-				input: 'type Point\n\tx: i32\n\ty: i32\np:Point\n\tx = 1',
+				input: 'Point\n\tx: i32\n\ty: i32\np:Point\n\tx = 1',
 			},
 			{
 				description: 'refinement type in field - constraint satisfied',
 				expect: 'valid',
-				input: 'type Point\n\tx: i32<min=0>\n\ty: i32\np:Point\n\tx = 5\n\ty = 10',
+				input: 'Point\n\tx: i32<min=0>\n\ty: i32\np:Point\n\tx = 5\n\ty = 10',
 			},
 			{
 				description: 'refinement type in field - constraint violated',
 				errorCode: 'TWCHECK041',
 				expect: 'check-error',
-				input: 'type Point\n\tx: i32<min=0>\n\ty: i32\np:Point\n\tx = -5\n\ty = 10',
+				input: 'Point\n\tx: i32<min=0>\n\ty: i32\np:Point\n\tx = -5\n\ty = 10',
 			},
 			{
 				description: 'multiple refinement fields',
 				expect: 'valid',
 				input:
-					'type Bounded\n\ta: i32<min=0, max=100>\n\tb: i32<min=-10>\np:Bounded\n\ta = 50\n\tb = -5',
+					'Bounded\n\ta: i32<min=0, max=100>\n\tb: i32<min=-10>\np:Bounded\n\ta = 50\n\tb = -5',
 			},
 			{
 				description: 'refinement field max constraint violated',
 				errorCode: 'TWCHECK041',
 				expect: 'check-error',
-				input: 'type Bounded\n\ta: i32<max=10>\np:Bounded\n\ta = 100',
+				input: 'Bounded\n\ta: i32<max=10>\np:Bounded\n\ta = 100',
 			},
 			{
 				description: 'record instantiation with new syntax',
 				expect: 'valid',
-				input: 'type Point\n\tx: i32\n\ty: i32\np:Point\n\tx = 5\n\ty = 10',
+				input: 'Point\n\tx: i32\n\ty: i32\np:Point\n\tx = 5\n\ty = 10',
 			},
 			{
 				description: 'nested record init with new syntax',
 				expect: 'valid',
-				input:
-					'type Inner\n\tval: i32\ntype Outer\n\tinner: Inner\no:Outer\n\tinner: Inner\n\t\tval = 5',
+				input: 'Inner\n\tval: i32\nOuter\n\tinner: Inner\no:Outer\n\tinner: Inner\n\t\tval = 5',
 			},
 			{
 				description: 'record field access with new syntax',
 				expect: 'valid',
-				input: 'type Point\n\tx: i32\np:Point\n\tx = 5\nresult:i32 = p.x',
+				input: 'Point\n\tx: i32\np:Point\n\tx = 5\nresult:i32 = p.x',
 			},
 		])
 	)
@@ -238,13 +237,13 @@ test('Semantic Specs', async (t) => {
 			{
 				description: 'simple field access',
 				expect: 'valid',
-				input: 'type Point\n\tx: i32\n\ty: i32\np:Point\n\tx = 1\n\ty = 2\nv:i32 = p.x',
+				input: 'Point\n\tx: i32\n\ty: i32\np:Point\n\tx = 1\n\ty = 2\nv:i32 = p.x',
 			},
 			{
 				description: 'nested field access',
 				expect: 'valid',
 				input:
-					'type Inner\n\tval: i32\ntype Outer\n\tinner: Inner\no:Outer\n\tinner: Inner\n\t\tval = 42\nv:i32 = o.inner.val',
+					'Inner\n\tval: i32\nOuter\n\tinner: Inner\no:Outer\n\tinner: Inner\n\t\tval = 42\nv:i32 = o.inner.val',
 			},
 		])
 	)


### PR DESCRIPTION
## Summary

Unifies expression handling by enabling multi-line lambda bodies (Expression Sequences) and simplifies record type declarations by removing the unnecessary `type` keyword. This brings the language closer to a uniform expression-based structure.

## Changes

- **Grammar**: 
  - Removed `type` keyword from record declarations (e.g., `type Point` → `Point`).
  - Added `LambdaBlock` and `LambdaBlockLine` rules for multi-line lambda bodies.
- **Parser**: 
  - Added semantic actions for `ExpressionSequence` to support interleaved statements and expressions in lambda bodies.
  - Added support for optional type annotations in function bindings.
- **Checker**: 
  - Implemented `ExpressionSequence` checking, allowing local bindings and side-effects before the final return expression in lambdas.
- **Codegen**: 
  - Improved local variable collection to correctly allocate bindings defined within function bodies.
- **Refactor**: 
  - Updated all record examples (`examples/records/*.tw`) and related tests to use the new concise record syntax.

## Test plan

- [x] `mise run test` passes (all package tests).
- [x] All `examples/records/*.tw` compile successfully with the new syntax.
- [x] Multi-line lambda bodies with local bindings are correctly compiled and executed.