### PR TITLE
Create labels for security and dependency issues

### DIFF
--- a/.github/workflows/check-action-versions.yml
+++ b/.github/workflows/check-action-versions.yml
@@ -162,6 +162,10 @@ jobs:
         run: |
           ISSUE_TITLE="Security: Outdated GitHub Actions detected"
 
+          # Ensure required labels exist
+          gh label create "security" --description "Security-related issues" --color "D93F0B" --force 2>/dev/null || true
+          gh label create "dependencies" --description "Dependency updates" --color "0366D6" --force 2>/dev/null || true
+
           EXISTING_ISSUE=$(gh issue list --state open --search "in:title $ISSUE_TITLE" --json number --jq '.[0].number' 2>/dev/null || echo "")
 
           if [[ -n "$EXISTING_ISSUE" ]]; then


### PR DESCRIPTION
Add security and dependencies labels to GitHub issues.

- Creates security (red) and dependencies (blue) labels before creating the issue