### PR TITLE
chore(deps): update all direct dependencies to latest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@
 !mise.toml
 !package-lock.json
 !package.json
+!patches/
+!patches/**
 !packages/
 !packages/**
 !pnpm-lock.yaml

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 # mise configuration for tinywhale monorepo
 [tools]
-node = "24.13.0"
-pnpm = "10.28.1"
+node = "24.15.0"
+pnpm = "10.33.0"
 
 [tasks.install]
 description = "Install dependencies"

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
 	"author": "",
 	"description": "A programming language with compiler, CLI, and LSP server",
 	"devDependencies": {
-		"@biomejs/biome": "2.3.12",
-		"@types/node": "25.0.10",
-		"fast-check": "4.5.3",
-		"typescript": "5.9.3"
+		"@biomejs/biome": "2.4.12",
+		"@types/node": "25.6.0",
+		"fast-check": "4.7.0",
+		"typescript": "6.0.3"
 	},
 	"engines": {
-		"node": "24.13.0",
-		"pnpm": "10.28.0"
+		"node": "24.15.0",
+		"pnpm": "10.33.0"
 	},
 	"keywords": [
 		"compiler",
@@ -18,7 +18,7 @@
 	],
 	"license": "MIT",
 	"name": "tinywhale",
-	"packageManager": "pnpm@10.28.0",
+	"packageManager": "pnpm@10.33.0",
 	"private": true,
 	"scripts": {
 		"start": "mise run"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
 	"license": "MIT",
 	"name": "tinywhale",
 	"packageManager": "pnpm@10.33.0",
+	"pnpm": {
+		"patchedDependencies": {
+			"binaryen@129.0.0-nightly.20260419": "patches/binaryen@129.0.0-nightly.20260419.patch"
+		}
+	},
 	"private": true,
 	"scripts": {
 		"start": "mise run"

--- a/packages/cli-compiler/package.json
+++ b/packages/cli-compiler/package.json
@@ -4,14 +4,14 @@
 		"tinywhale": "./dist/cli.js"
 	},
 	"dependencies": {
-		"@adonisjs/ace": "13.4.0",
+		"@adonisjs/ace": "14.1.0",
 		"@tinywhale/compiler": "workspace:*",
 		"@tinywhale/diagnostics": "workspace:*"
 	},
 	"description": "TinyWhale command-line interface",
 	"devDependencies": {
-		"@types/node": "25.0.10",
-		"typescript": "5.9.3"
+		"@types/node": "25.6.0",
+		"typescript": "6.0.3"
 	},
 	"exports": {
 		".": {

--- a/packages/cli-grammar-test/package.json
+++ b/packages/cli-grammar-test/package.json
@@ -4,14 +4,14 @@
 		"tw-grammar-test": "./dist/cli/index.js"
 	},
 	"dependencies": {
-		"@adonisjs/ace": "13.4.0",
+		"@adonisjs/ace": "14.1.0",
 		"@tinywhale/grammar-test": "workspace:*",
-		"ohm-js": "17.3.0"
+		"ohm-js": "17.5.0"
 	},
 	"description": "CLI for grammar testing and analysis",
 	"devDependencies": {
-		"@types/node": "25.0.10",
-		"typescript": "5.9.3"
+		"@types/node": "25.6.0",
+		"typescript": "6.0.3"
 	},
 	"files": [
 		"dist"

--- a/packages/cli-lsp/package.json
+++ b/packages/cli-lsp/package.json
@@ -4,13 +4,13 @@
 		"tinywhale-lsp": "./dist/cli.js"
 	},
 	"dependencies": {
-		"@adonisjs/ace": "13.4.0",
+		"@adonisjs/ace": "14.1.0",
 		"@tinywhale/lsp": "workspace:*"
 	},
 	"description": "TinyWhale Language Server CLI",
 	"devDependencies": {
-		"@types/node": "25.0.10",
-		"typescript": "5.9.3"
+		"@types/node": "25.6.0",
+		"typescript": "6.0.3"
 	},
 	"exports": {
 		".": {

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -2,15 +2,15 @@
 	"author": "",
 	"dependencies": {
 		"@tinywhale/diagnostics": "workspace:*",
-		"binaryen": "125.0.0",
-		"ohm-js": "17.3.0"
+		"binaryen": "129.0.0",
+		"ohm-js": "17.5.0"
 	},
 	"description": "TinyWhale compiler library",
 	"devDependencies": {
 		"@ohm-js/cli": "2.0.1",
 		"@tinywhale/grammar-test": "workspace:*",
-		"@types/node": "25.0.10",
-		"typescript": "5.9.3"
+		"@types/node": "25.6.0",
+		"typescript": "6.0.3"
 	},
 	"exports": {
 		".": {

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -2,7 +2,7 @@
 	"author": "",
 	"dependencies": {
 		"@tinywhale/diagnostics": "workspace:*",
-		"binaryen": "129.0.0",
+		"binaryen": "129.0.0-nightly.20260419",
 		"ohm-js": "17.5.0"
 	},
 	"description": "TinyWhale compiler library",

--- a/packages/compiler/src/check/declarations.ts
+++ b/packages/compiler/src/check/declarations.ts
@@ -276,4 +276,4 @@ export function finalizeTypeDecl(state: CheckerState, _context: CompilationConte
 // ============================================================================
 
 // These are used by checker.ts for FieldInit handling in TypeDecl context
-export { getFieldDeclFromLine, resolveUserDefinedFieldType, addFieldToTypeDeclContext }
+export { addFieldToTypeDeclContext, getFieldDeclFromLine, resolveUserDefinedFieldType }

--- a/packages/compiler/src/check/utils.ts
+++ b/packages/compiler/src/check/utils.ts
@@ -104,6 +104,10 @@ export function splitBigIntTo32BitParts(
 	return { high, low }
 }
 
+export function combine32BitPartsToBigInt(low: number, high: number): bigint {
+	return (BigInt(high) << 32n) | BigInt(low >>> 0)
+}
+
 /**
  * Checks if a value is representable as f32.
  */

--- a/packages/compiler/src/codegen/index.ts
+++ b/packages/compiler/src/codegen/index.ts
@@ -67,11 +67,6 @@ export interface CompileResult {
 	warnings: CompileWarning[]
 }
 
-// binaryen 129 changed i64.const to take a single bigint; bundled .d.ts still types it as (low, high).
-function i64Const(mod: binaryen.Module, value: bigint): binaryen.ExpressionRef {
-	return (mod.i64 as unknown as { const: (v: bigint) => binaryen.ExpressionRef }).const(value)
-}
-
 function toBinaryenType(typeId: TypeId, context: CompilationContext): binaryen.Type {
 	const wasmTypeId = context.types?.toWasmType(typeId) ?? typeId
 
@@ -114,7 +109,7 @@ function emitIntConst(
 ): binaryen.ExpressionRef {
 	const binaryenType = toBinaryenType(inst.typeId, context)
 	if (binaryenType === binaryen.i64) {
-		return i64Const(mod, combine32BitPartsToBigInt(getIntConstLow(inst), getIntConstHigh(inst)))
+		return mod.i64.const(combine32BitPartsToBigInt(getIntConstLow(inst), getIntConstHigh(inst)))
 	}
 	return mod.i32.const(getIntConstLow(inst))
 }
@@ -216,7 +211,7 @@ function emitNegate(
 		case binaryen.i32:
 			return mod.i32.sub(mod.i32.const(0), operand)
 		case binaryen.i64:
-			return mod.i64.sub(i64Const(mod, 0n), operand)
+			return mod.i64.sub(mod.i64.const(0n), operand)
 		case binaryen.f32:
 			return mod.f32.neg(operand)
 		case binaryen.f64:
@@ -242,7 +237,7 @@ function emitBitwiseNot(
 		case binaryen.i32:
 			return mod.i32.xor(operand, mod.i32.const(-1))
 		case binaryen.i64:
-			return mod.i64.xor(operand, i64Const(mod, -1n))
+			return mod.i64.xor(operand, mod.i64.const(-1n))
 		default:
 			return null
 	}
@@ -274,8 +269,8 @@ function emitEuclideanMod(
 	}
 	if (binaryenType === binaryen.i64) {
 		const absB = mod.select(
-			mod.i64.lt_s(right, i64Const(mod, 0n)),
-			mod.i64.sub(i64Const(mod, 0n), right),
+			mod.i64.lt_s(right, mod.i64.const(0n)),
+			mod.i64.sub(mod.i64.const(0n), right),
 			right
 		)
 		const remainder = mod.i64.rem_s(left, right)
@@ -499,7 +494,7 @@ function emitLiteralComparison(
 	const binaryenType = toBinaryenType(typeId, context)
 
 	if (binaryenType === binaryen.i64) {
-		return mod.i64.eq(scrutineeExpr, i64Const(mod, value))
+		return mod.i64.eq(scrutineeExpr, mod.i64.const(value))
 	}
 
 	return mod.i32.eq(scrutineeExpr, mod.i32.const(Number(value)))

--- a/packages/compiler/src/codegen/index.ts
+++ b/packages/compiler/src/codegen/index.ts
@@ -35,6 +35,7 @@ import {
 	type SymbolId,
 	type TypeId,
 } from '../check/types.ts'
+import { combine32BitPartsToBigInt } from '../check/utils.ts'
 import { type CompilationContext, DiagnosticSeverity, type StringId } from '../core/context.ts'
 import type { DiagnosticCode } from '../core/diagnostics.ts'
 import { type NodeId, NodeKind } from '../core/nodes.ts'
@@ -64,6 +65,11 @@ export interface CompileResult {
 	text: string
 	valid: boolean
 	warnings: CompileWarning[]
+}
+
+// binaryen 129 changed i64.const to take a single bigint; bundled .d.ts still types it as (low, high).
+function i64Const(mod: binaryen.Module, value: bigint): binaryen.ExpressionRef {
+	return (mod.i64 as unknown as { const: (v: bigint) => binaryen.ExpressionRef }).const(value)
 }
 
 function toBinaryenType(typeId: TypeId, context: CompilationContext): binaryen.Type {
@@ -108,7 +114,7 @@ function emitIntConst(
 ): binaryen.ExpressionRef {
 	const binaryenType = toBinaryenType(inst.typeId, context)
 	if (binaryenType === binaryen.i64) {
-		return mod.i64.const(getIntConstLow(inst), getIntConstHigh(inst))
+		return i64Const(mod, combine32BitPartsToBigInt(getIntConstLow(inst), getIntConstHigh(inst)))
 	}
 	return mod.i32.const(getIntConstLow(inst))
 }
@@ -210,7 +216,7 @@ function emitNegate(
 		case binaryen.i32:
 			return mod.i32.sub(mod.i32.const(0), operand)
 		case binaryen.i64:
-			return mod.i64.sub(mod.i64.const(0, 0), operand)
+			return mod.i64.sub(i64Const(mod, 0n), operand)
 		case binaryen.f32:
 			return mod.f32.neg(operand)
 		case binaryen.f64:
@@ -236,7 +242,7 @@ function emitBitwiseNot(
 		case binaryen.i32:
 			return mod.i32.xor(operand, mod.i32.const(-1))
 		case binaryen.i64:
-			return mod.i64.xor(operand, mod.i64.const(-1, -1))
+			return mod.i64.xor(operand, i64Const(mod, -1n))
 		default:
 			return null
 	}
@@ -268,8 +274,8 @@ function emitEuclideanMod(
 	}
 	if (binaryenType === binaryen.i64) {
 		const absB = mod.select(
-			mod.i64.lt_s(right, mod.i64.const(0, 0)),
-			mod.i64.sub(mod.i64.const(0, 0), right),
+			mod.i64.lt_s(right, i64Const(mod, 0n)),
+			mod.i64.sub(i64Const(mod, 0n), right),
 			right
 		)
 		const remainder = mod.i64.rem_s(left, right)
@@ -493,9 +499,7 @@ function emitLiteralComparison(
 	const binaryenType = toBinaryenType(typeId, context)
 
 	if (binaryenType === binaryen.i64) {
-		const low = Number(BigInt.asIntN(32, value))
-		const high = Number(BigInt.asIntN(32, value >> 32n))
-		return mod.i64.eq(scrutineeExpr, mod.i64.const(low, high))
+		return mod.i64.eq(scrutineeExpr, i64Const(mod, value))
 	}
 
 	return mod.i32.eq(scrutineeExpr, mod.i32.const(Number(value)))

--- a/packages/compiler/test/compile.property.test.ts
+++ b/packages/compiler/test/compile.property.test.ts
@@ -7,9 +7,7 @@ const validProgramArb = fc.oneof(
 	// Single panic
 	fc.constant('panic\n'),
 	// Multiple panics
-	fc
-		.integer({ max: 10, min: 1 })
-		.map((n) => 'panic\n'.repeat(n)),
+	fc.integer({ max: 10, min: 1 }).map((n) => 'panic\n'.repeat(n)),
 	// Variable binding with panic
 	fc
 		.tuple(fc.constantFrom('i32', 'i64', 'f32', 'f64'), fc.integer({ max: 1000, min: 0 }))
@@ -20,12 +18,10 @@ const validProgramArb = fc.oneof(
 			return `x:${type} = ${value}\npanic\n`
 		}),
 	// Multiple bindings with panic
-	fc
-		.integer({ max: 5, min: 1 })
-		.map((n) => {
-			const bindings = Array.from({ length: n }, (_, i) => `v${i}:i32 = ${i}`).join('\n')
-			return `${bindings}\npanic\n`
-		})
+	fc.integer({ max: 5, min: 1 }).map((n) => {
+		const bindings = Array.from({ length: n }, (_, i) => `v${i}:i32 = ${i}`).join('\n')
+		return `${bindings}\npanic\n`
+	})
 )
 
 describe('compile/pipeline properties', () => {

--- a/packages/grammar-test/package.json
+++ b/packages/grammar-test/package.json
@@ -1,12 +1,12 @@
 {
 	"author": "",
 	"dependencies": {
-		"ohm-js": "17.3.0"
+		"ohm-js": "17.5.0"
 	},
 	"description": "Generic Ohm.js grammar testing framework and library",
 	"devDependencies": {
-		"@types/node": "25.0.10",
-		"typescript": "5.9.3"
+		"@types/node": "25.6.0",
+		"typescript": "6.0.3"
 	},
 	"exports": {
 		".": {

--- a/packages/lsp/package.json
+++ b/packages/lsp/package.json
@@ -5,8 +5,8 @@
 	},
 	"description": "TinyWhale Language Server Protocol implementation",
 	"devDependencies": {
-		"@types/node": "25.0.10",
-		"typescript": "5.9.3"
+		"@types/node": "25.6.0",
+		"typescript": "6.0.3"
 	},
 	"exports": {
 		".": {

--- a/patches/binaryen@129.0.0-nightly.20260419.patch
+++ b/patches/binaryen@129.0.0-nightly.20260419.patch
@@ -1,0 +1,13 @@
+diff --git a/index.d.ts b/index.d.ts
+index 0000000..0000001 100644
+--- a/index.d.ts
++++ b/index.d.ts
+@@ -1331,7 +1331,7 @@ declare module binaryen {
+       ge_u(left: ExpressionRef, right: ExpressionRef): ExpressionRef;
+       atomic: {
+         load(offset: number, ptr: ExpressionRef, name?: string, order?: MemoryOrder): ExpressionRef;
+-        load8_u(offset: number, ptr: ExpressionRef, name?: string, order?: MemoryOrder: ExpressionRef;
++        load8_u(offset: number, ptr: ExpressionRef, name?: string, order?: MemoryOrder): ExpressionRef;
+         load16_u(offset: number, ptr: ExpressionRef, name?: string, order?: MemoryOrder): ExpressionRef;
+         load32_u(offset: number, ptr: ExpressionRef, name?: string, order?: MemoryOrder): ExpressionRef;
+         store(offset: number, ptr: ExpressionRef, value: ExpressionRef, name?: string, order?: MemoryOrder): ExpressionRef;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,23 +9,23 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.3.12
-        version: 2.3.12
+        specifier: 2.4.12
+        version: 2.4.12
       '@types/node':
-        specifier: 25.0.10
-        version: 25.0.10
+        specifier: 25.6.0
+        version: 25.6.0
       fast-check:
-        specifier: 4.5.3
-        version: 4.5.3
+        specifier: 4.7.0
+        version: 4.7.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/cli-compiler:
     dependencies:
       '@adonisjs/ace':
-        specifier: 13.4.0
-        version: 13.4.0
+        specifier: 14.1.0
+        version: 14.1.0(youch@3.3.4)
       '@tinywhale/compiler':
         specifier: workspace:*
         version: link:../compiler
@@ -34,46 +34,46 @@ importers:
         version: link:../diagnostics
     devDependencies:
       '@types/node':
-        specifier: 25.0.10
-        version: 25.0.10
+        specifier: 25.6.0
+        version: 25.6.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/cli-grammar-test:
     dependencies:
       '@adonisjs/ace':
-        specifier: 13.4.0
-        version: 13.4.0
+        specifier: 14.1.0
+        version: 14.1.0(youch@3.3.4)
       '@tinywhale/grammar-test':
         specifier: workspace:*
         version: link:../grammar-test
       ohm-js:
-        specifier: 17.3.0
-        version: 17.3.0
+        specifier: 17.5.0
+        version: 17.5.0
     devDependencies:
       '@types/node':
-        specifier: 25.0.10
-        version: 25.0.10
+        specifier: 25.6.0
+        version: 25.6.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/cli-lsp:
     dependencies:
       '@adonisjs/ace':
-        specifier: 13.4.0
-        version: 13.4.0
+        specifier: 14.1.0
+        version: 14.1.0(youch@3.3.4)
       '@tinywhale/lsp':
         specifier: workspace:*
         version: link:../lsp
     devDependencies:
       '@types/node':
-        specifier: 25.0.10
-        version: 25.0.10
+        specifier: 25.6.0
+        version: 25.6.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/compiler:
     dependencies:
@@ -81,39 +81,39 @@ importers:
         specifier: workspace:*
         version: link:../diagnostics
       binaryen:
-        specifier: 125.0.0
-        version: 125.0.0
+        specifier: 129.0.0
+        version: 129.0.0
       ohm-js:
-        specifier: 17.3.0
-        version: 17.3.0
+        specifier: 17.5.0
+        version: 17.5.0
     devDependencies:
       '@ohm-js/cli':
         specifier: 2.0.1
-        version: 2.0.1(ohm-js@17.3.0)
+        version: 2.0.1(ohm-js@17.5.0)
       '@tinywhale/grammar-test':
         specifier: workspace:*
         version: link:../grammar-test
       '@types/node':
-        specifier: 25.0.10
-        version: 25.0.10
+        specifier: 25.6.0
+        version: 25.6.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/diagnostics: {}
 
   packages/grammar-test:
     dependencies:
       ohm-js:
-        specifier: 17.3.0
-        version: 17.3.0
+        specifier: 17.5.0
+        version: 17.5.0
     devDependencies:
       '@types/node':
-        specifier: 25.0.10
-        version: 25.0.10
+        specifier: 25.6.0
+        version: 25.6.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/lsp:
     dependencies:
@@ -122,67 +122,73 @@ importers:
         version: link:../compiler
     devDependencies:
       '@types/node':
-        specifier: 25.0.10
-        version: 25.0.10
+        specifier: 25.6.0
+        version: 25.6.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
 packages:
 
-  '@adonisjs/ace@13.4.0':
-    resolution: {integrity: sha512-7Wq6CpXmQm3m/6fKfzubAadCdiH2kKSni+K8s5KcTIFryKSqW+f06UAPOUwRJWqy80hnVlujAjveIsNJSPeJjA==}
-    engines: {node: '>=18.16.0'}
+  '@adonisjs/ace@14.1.0':
+    resolution: {integrity: sha512-8N8z1YKePBiXz7wLxHFz/HSqjCRSL/9Vzs4XQt8gk8G17u4PXwNncWt0vSgYEcDrvPAt+QOavY1vMeKOOWe29w==}
+    engines: {node: '>=24.0.0'}
+    peerDependencies:
+      youch: ^4.1.0-beta.11 || ^4.1.0
 
-  '@biomejs/biome@2.3.12':
-    resolution: {integrity: sha512-AR7h4aSlAvXj7TAajW/V12BOw2EiS0AqZWV5dGozf4nlLoUF/ifvD0+YgKSskT0ylA6dY1A8AwgP8kZ6yaCQnA==}
+  '@biomejs/biome@2.4.12':
+    resolution: {integrity: sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.3.12':
-    resolution: {integrity: sha512-cO6fn+KiMBemva6EARDLQBxeyvLzgidaFRJi8G7OeRqz54kWK0E+uSjgFaiHlc3DZYoa0+1UFE8mDxozpc9ieg==}
+  '@biomejs/cli-darwin-arm64@2.4.12':
+    resolution: {integrity: sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.3.12':
-    resolution: {integrity: sha512-/fiF/qmudKwSdvmSrSe/gOTkW77mHHkH8Iy7YC2rmpLuk27kbaUOPa7kPiH5l+3lJzTUfU/t6x1OuIq/7SGtxg==}
+  '@biomejs/cli-darwin-x64@2.4.12':
+    resolution: {integrity: sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.3.12':
-    resolution: {integrity: sha512-aqkeSf7IH+wkzFpKeDVPSXy9uDjxtLpYA6yzkYsY+tVjwFFirSuajHDI3ul8en90XNs1NA0n8kgBrjwRi5JeyA==}
+  '@biomejs/cli-linux-arm64-musl@2.4.12':
+    resolution: {integrity: sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.3.12':
-    resolution: {integrity: sha512-nbOsuQROa3DLla5vvsTZg+T5WVPGi9/vYxETm9BOuLHBJN3oWQIg3MIkE2OfL18df1ZtNkqXkH6Yg9mdTPem7A==}
+  '@biomejs/cli-linux-arm64@2.4.12':
+    resolution: {integrity: sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.3.12':
-    resolution: {integrity: sha512-kVGWtupRRsOjvw47YFkk5mLiAdpCPMWBo1jOwAzh+juDpUb2sWarIp+iq+CPL1Wt0LLZnYtP7hH5kD6fskcxmg==}
+  '@biomejs/cli-linux-x64-musl@2.4.12':
+    resolution: {integrity: sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.3.12':
-    resolution: {integrity: sha512-CQtqrJ+qEEI8tgRSTjjzk6wJAwfH3wQlkIGsM5dlecfRZaoT+XCms/mf7G4kWNexrke6mnkRzNy6w8ebV177ow==}
+  '@biomejs/cli-linux-x64@2.4.12':
+    resolution: {integrity: sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.3.12':
-    resolution: {integrity: sha512-Re4I7UnOoyE4kHMqpgtG6UvSBGBbbtvsOvBROgCCoH7EgANN6plSQhvo2W7OCITvTp7gD6oZOyZy72lUdXjqZg==}
+  '@biomejs/cli-win32-arm64@2.4.12':
+    resolution: {integrity: sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.3.12':
-    resolution: {integrity: sha512-qqGVWqNNek0KikwPZlOIoxtXgsNGsX+rgdEzgw82Re8nF02W+E2WokaQhpF5TdBh/D/RQ3TLppH+otp6ztN0lw==}
+  '@biomejs/cli-win32-x64@2.4.12':
+    resolution: {integrity: sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -209,8 +215,8 @@ packages:
     peerDependencies:
       ohm-js: ^17.0.0
 
-  '@poppinss/cliui@6.7.0':
-    resolution: {integrity: sha512-ihlhDUHw4Lfx6Euo8SSDar/rHHD8T1aFXJ1Z3NYSYjHcr9rSK5iy6zC5xvQJCeGY1BTninW520iKv/hd4lS0tA==}
+  '@poppinss/cliui@6.8.1':
+    resolution: {integrity: sha512-o/ssbwr+r6woG65rk9eFHnn9dVUphZr/Rk+4+05ENVMBWYpYhTJGdE9RobTG5JLFubvO4gWIyFeNlC+I4EM6eA==}
 
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
@@ -221,8 +227,8 @@ packages:
   '@poppinss/hooks@7.3.0':
     resolution: {integrity: sha512-/H35z/bWqHg7085QOxWUDYMidx6Kl6b8kIyzIXlRYzWvsk1xm9hQOlXWdWEYch+Gmn8eL7tThx59MBj8BLxDrQ==}
 
-  '@poppinss/macroable@1.1.0':
-    resolution: {integrity: sha512-y/YKzZDuG8XrpXpM7Z1RdQpiIc0MAKyva24Ux1PB4aI7RiSI/79K8JVDcdyubriTm7vJ1LhFs8CrZpmPnx/8Pw==}
+  '@poppinss/macroable@1.1.2':
+    resolution: {integrity: sha512-FAVBRzzWhYP5mA3lCwLH1A0fKBqq5anyjGet90Z81aRK5c/+LTGUE1zJhZrErjaenBSOOI9BVUs3WVmotneFQA==}
 
   '@poppinss/object-builder@1.1.0':
     resolution: {integrity: sha512-FOrOq52l7u8goR5yncX14+k+Ewi5djnrt1JwXeS/FvnwAPOiveFhiczCDuvXdssAwamtrV2hp5Rw9v+n2T7hQg==}
@@ -234,12 +240,14 @@ packages:
   '@poppinss/string@1.7.1':
     resolution: {integrity: sha512-OrLzv/nGDU6l6dLXIQHe8nbNSWWfuSbpB/TW5nRpZFf49CLuQlIHlSPN9IdSUv2vG+59yGM6LoibsaHn8B8mDw==}
 
-  '@poppinss/utils@6.10.1':
-    resolution: {integrity: sha512-da+MMyeXhBaKtxQiWPfy7+056wk3lVIhioJnXHXkJ2/OHDaZfFcyKHNl1R06sdYO8lIRXcXdoZ6LO2ARmkAREA==}
-    engines: {node: '>=18.16.0'}
+  '@poppinss/types@1.2.1':
+    resolution: {integrity: sha512-qUYnzl0m9HJTWsXtr8Xo7CwDx6wcjrvo14bOVbIMIlKJCzKrm3LX55dRTDr1/x4PpSvKVgmxvC6Ly2YiqXKOvQ==}
 
-  '@types/node@25.0.10':
-    resolution: {integrity: sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==}
+  '@poppinss/utils@7.0.1':
+    resolution: {integrity: sha512-mveSvLI2YPC114mK5HCuSYfUtjpClf1wHG1VCqZJCp4U2ypPhIt62Iku5urh0kPAFvnvCVHx2bXBSH14qMTOlQ==}
+
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
   '@types/pluralize@0.0.33':
     resolution: {integrity: sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==}
@@ -248,8 +256,8 @@ packages:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
 
-  ansi-escapes@7.2.0:
-    resolution: {integrity: sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==}
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
 
   ansi-regex@5.0.1:
@@ -267,8 +275,8 @@ packages:
   as-table@1.0.55:
     resolution: {integrity: sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==}
 
-  binaryen@125.0.0:
-    resolution: {integrity: sha512-X7CUM9ZnwL/Ow++JH5AJKiemc82J7JyeryuPvXQdXBLcL/rqrC5KMUB1mHiORSolietH9sotvaOZlr6HSwPAlw==}
+  binaryen@129.0.0:
+    resolution: {integrity: sha512-NyF5J0SfRoLDthpPh36FGTycOEv3Eqnkq3+mP5Cqt6iD9BLGGJMEVuPzu81nhLy2MMpPKmRTM9VLZihfyRQv8A==}
     hasBin: true
 
   braces@3.0.3:
@@ -279,6 +287,10 @@ packages:
     resolution: {integrity: sha512-wljhAjDDIv/hM2FzgJnYQg90AWmZMNtESCjTeLH680qTzdo0nErlCxOmgzgX4ZsZAtIvqHyD87ES8QyriXB+BQ==}
     engines: {node: '>=18'}
 
+  cli-boxes@4.0.1:
+    resolution: {integrity: sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==}
+    engines: {node: '>=18.20 <19 || >=20.10'}
+
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
@@ -287,8 +299,8 @@ packages:
     resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
     engines: {node: 10.* || >= 12.*}
 
-  cli-truncate@5.1.1:
-    resolution: {integrity: sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==}
+  cli-truncate@5.2.0:
+    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
     engines: {node: '>=20'}
 
   commander@8.3.0:
@@ -302,9 +314,6 @@ packages:
   data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
 
-  emoji-regex@10.6.0:
-    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
-
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -316,8 +325,8 @@ packages:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
 
-  fast-check@4.5.3:
-    resolution: {integrity: sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA==}
+  fast-check@4.7.0:
+    resolution: {integrity: sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==}
     engines: {node: '>=12.17.0'}
 
   fast-glob@3.3.3:
@@ -341,6 +350,10 @@ packages:
 
   get-east-asian-width@1.4.0:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
+    engines: {node: '>=18'}
+
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
 
   get-source@2.0.12:
@@ -377,8 +390,8 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
-  log-update@7.0.2:
-    resolution: {integrity: sha512-cSSF1K5w9juI2+JeSRAdaTUZJf6cJB0aWwWO1nQQkcWw44+bIfXmhZMwK2eEsv6tXvU3UfKX/kzcX6SP+1tLAw==}
+  log-update@7.2.0:
+    resolution: {integrity: sha512-iLs7dGSyjZiUgvrUvuD3FndAxVJk+TywBkkkwUSm9HdYoskJalWg5qVsEiXeufPvRVPbCUmNQewg798rx+sPXg==}
     engines: {node: '>=20'}
 
   merge2@1.4.1:
@@ -397,16 +410,16 @@ packages:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
     hasBin: true
 
-  ohm-js@17.3.0:
-    resolution: {integrity: sha512-LySMdjweN1hKBMMV8lM44+1wiewkndDNNJxtgVAscs7y683MXCdQZLsIaw64/p8NuqYbKOWZoHIOA5DU/xchoA==}
+  ohm-js@17.5.0:
+    resolution: {integrity: sha512-l4Sa7026+6jsvYbt0PXKmL+f+ML32fD++IznLgxDhx2t9Cx6NC7zwRqblCujPHGGmkQerHoeBzRutdxaw/S72g==}
     engines: {node: '>=0.12.1'}
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
   pluralize@8.0.0:
@@ -420,8 +433,8 @@ packages:
   printable-characters@1.0.42:
     resolution: {integrity: sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==}
 
-  pure-rand@7.0.1:
-    resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -437,20 +450,13 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  safe-stable-stringify@2.5.0:
-    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
-    engines: {node: '>=10'}
-
-  secure-json-parse@4.1.0:
-    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
-
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  slice-ansi@7.1.2:
-    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
-    engines: {node: '>=18'}
+  slice-ansi@8.0.0:
+    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
+    engines: {node: '>=20'}
 
   slugify@1.6.6:
     resolution: {integrity: sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==}
@@ -460,19 +466,15 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
-  stacktracey@2.1.8:
-    resolution: {integrity: sha512-Kpij9riA+UNg7TnphqjH7/CzctQ/owJGNbFkfEeve4Z4uxT5+JapVLFXcsurIfN34gnTWZNJ/f7NMG0E8JDzTw==}
+  stacktracey@2.2.0:
+    resolution: {integrity: sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
-  string-width@7.2.0:
-    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
-    engines: {node: '>=18'}
-
-  string-width@8.1.0:
-    resolution: {integrity: sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==}
+  string-width@8.2.0:
+    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
     engines: {node: '>=20'}
 
   strip-ansi@6.0.1:
@@ -483,88 +485,89 @@ packages:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
 
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
+  terminal-size@4.0.1:
+    resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
     engines: {node: '>=18'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  wordwrap@1.0.0:
-    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
+  wrap-ansi@10.0.0:
+    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
+    engines: {node: '>=20'}
 
-  wrap-ansi@9.0.2:
-    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
-    engines: {node: '>=18'}
-
-  yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
-
-  youch-terminal@2.2.3:
-    resolution: {integrity: sha512-/PE77ZwG072tXBvF47S9RL9/G80u86icZ5QwyjblyM67L4n/T5qQeM3Xrecbu8kkDDr/9T/PTj/X+6G/OSRQug==}
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   youch@3.3.4:
     resolution: {integrity: sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==}
 
 snapshots:
 
-  '@adonisjs/ace@13.4.0':
+  '@adonisjs/ace@14.1.0(youch@3.3.4)':
     dependencies:
-      '@poppinss/cliui': 6.7.0
+      '@poppinss/cliui': 6.8.1
       '@poppinss/hooks': 7.3.0
-      '@poppinss/macroable': 1.1.0
+      '@poppinss/macroable': 1.1.2
       '@poppinss/prompts': 3.1.6
-      '@poppinss/utils': 6.10.1
+      '@poppinss/utils': 7.0.1
       fastest-levenshtein: 1.0.16
       jsonschema: 1.5.0
-      string-width: 7.2.0
-      yargs-parser: 21.1.1
+      string-width: 8.2.0
+      yargs-parser: 22.0.0
       youch: 3.3.4
-      youch-terminal: 2.2.3
 
-  '@biomejs/biome@2.3.12':
+  '@biomejs/biome@2.4.12':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.3.12
-      '@biomejs/cli-darwin-x64': 2.3.12
-      '@biomejs/cli-linux-arm64': 2.3.12
-      '@biomejs/cli-linux-arm64-musl': 2.3.12
-      '@biomejs/cli-linux-x64': 2.3.12
-      '@biomejs/cli-linux-x64-musl': 2.3.12
-      '@biomejs/cli-win32-arm64': 2.3.12
-      '@biomejs/cli-win32-x64': 2.3.12
+      '@biomejs/cli-darwin-arm64': 2.4.12
+      '@biomejs/cli-darwin-x64': 2.4.12
+      '@biomejs/cli-linux-arm64': 2.4.12
+      '@biomejs/cli-linux-arm64-musl': 2.4.12
+      '@biomejs/cli-linux-x64': 2.4.12
+      '@biomejs/cli-linux-x64-musl': 2.4.12
+      '@biomejs/cli-win32-arm64': 2.4.12
+      '@biomejs/cli-win32-x64': 2.4.12
 
-  '@biomejs/cli-darwin-arm64@2.3.12':
+  '@biomejs/cli-darwin-arm64@2.4.12':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.3.12':
+  '@biomejs/cli-darwin-x64@2.4.12':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.3.12':
+  '@biomejs/cli-linux-arm64-musl@2.4.12':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.3.12':
+  '@biomejs/cli-linux-arm64@2.4.12':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.3.12':
+  '@biomejs/cli-linux-x64-musl@2.4.12':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.3.12':
+  '@biomejs/cli-linux-x64@2.4.12':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.3.12':
+  '@biomejs/cli-win32-arm64@2.4.12':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.3.12':
+  '@biomejs/cli-win32-x64@2.4.12':
     optional: true
 
   '@colors/colors@1.5.0':
@@ -582,21 +585,23 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@ohm-js/cli@2.0.1(ohm-js@17.3.0)':
+  '@ohm-js/cli@2.0.1(ohm-js@17.5.0)':
     dependencies:
       commander: 8.3.0
       fast-glob: 3.3.3
-      ohm-js: 17.3.0
+      ohm-js: 17.5.0
 
-  '@poppinss/cliui@6.7.0':
+  '@poppinss/cliui@6.8.1':
     dependencies:
       '@poppinss/colors': 4.1.6
+      cli-boxes: 4.0.1
       cli-table3: 0.6.5
-      cli-truncate: 5.1.1
-      log-update: 7.0.2
+      cli-truncate: 5.2.0
+      log-update: 7.2.0
       pretty-hrtime: 1.0.3
-      string-width: 8.1.0
+      string-width: 8.2.0
       supports-color: 10.2.2
+      terminal-size: 4.0.1
 
   '@poppinss/colors@4.1.6':
     dependencies:
@@ -606,7 +611,7 @@ snapshots:
 
   '@poppinss/hooks@7.3.0': {}
 
-  '@poppinss/macroable@1.1.0': {}
+  '@poppinss/macroable@1.1.2': {}
 
   '@poppinss/object-builder@1.1.0': {}
 
@@ -624,24 +629,25 @@ snapshots:
       pluralize: 8.0.0
       slugify: 1.6.6
 
-  '@poppinss/utils@6.10.1':
+  '@poppinss/types@1.2.1': {}
+
+  '@poppinss/utils@7.0.1':
     dependencies:
       '@poppinss/exception': 1.2.3
       '@poppinss/object-builder': 1.1.0
       '@poppinss/string': 1.7.1
+      '@poppinss/types': 1.2.1
       flattie: 1.1.1
-      safe-stable-stringify: 2.5.0
-      secure-json-parse: 4.1.0
 
-  '@types/node@25.0.10':
+  '@types/node@25.6.0':
     dependencies:
-      undici-types: 7.16.0
+      undici-types: 7.19.2
 
   '@types/pluralize@0.0.33': {}
 
   ansi-colors@4.1.3: {}
 
-  ansi-escapes@7.2.0:
+  ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
 
@@ -655,13 +661,15 @@ snapshots:
     dependencies:
       printable-characters: 1.0.42
 
-  binaryen@125.0.0: {}
+  binaryen@129.0.0: {}
 
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
 
   case-anything@3.1.2: {}
+
+  cli-boxes@4.0.1: {}
 
   cli-cursor@5.0.0:
     dependencies:
@@ -673,18 +681,16 @@ snapshots:
     optionalDependencies:
       '@colors/colors': 1.5.0
 
-  cli-truncate@5.1.1:
+  cli-truncate@5.2.0:
     dependencies:
-      slice-ansi: 7.1.2
-      string-width: 8.1.0
+      slice-ansi: 8.0.0
+      string-width: 8.2.0
 
   commander@8.3.0: {}
 
   cookie@0.7.2: {}
 
   data-uri-to-buffer@2.0.2: {}
-
-  emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
 
@@ -695,9 +701,9 @@ snapshots:
 
   environment@1.1.0: {}
 
-  fast-check@4.5.3:
+  fast-check@4.7.0:
     dependencies:
-      pure-rand: 7.0.1
+      pure-rand: 8.4.0
 
   fast-glob@3.3.3:
     dependencies:
@@ -720,6 +726,8 @@ snapshots:
   flattie@1.1.1: {}
 
   get-east-asian-width@1.4.0: {}
+
+  get-east-asian-width@1.5.0: {}
 
   get-source@2.0.12:
     dependencies:
@@ -748,32 +756,32 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  log-update@7.0.2:
+  log-update@7.2.0:
     dependencies:
-      ansi-escapes: 7.2.0
+      ansi-escapes: 7.3.0
       cli-cursor: 5.0.0
-      slice-ansi: 7.1.2
-      strip-ansi: 7.1.2
-      wrap-ansi: 9.0.2
+      slice-ansi: 8.0.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 10.0.0
 
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mimic-function@5.0.1: {}
 
   mustache@4.2.0: {}
 
-  ohm-js@17.3.0: {}
+  ohm-js@17.5.0: {}
 
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
   pluralize@8.0.0: {}
 
@@ -781,7 +789,7 @@ snapshots:
 
   printable-characters@1.0.42: {}
 
-  pure-rand@7.0.1: {}
+  pure-rand@8.4.0: {}
 
   queue-microtask@1.2.3: {}
 
@@ -796,13 +804,9 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  safe-stable-stringify@2.5.0: {}
-
-  secure-json-parse@4.1.0: {}
-
   signal-exit@4.1.0: {}
 
-  slice-ansi@7.1.2:
+  slice-ansi@8.0.0:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
@@ -811,7 +815,7 @@ snapshots:
 
   source-map@0.6.1: {}
 
-  stacktracey@2.1.8:
+  stacktracey@2.2.0:
     dependencies:
       as-table: 1.0.55
       get-source: 2.0.12
@@ -822,15 +826,9 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
-  string-width@7.2.0:
+  string-width@8.2.0:
     dependencies:
-      emoji-regex: 10.6.0
-      get-east-asian-width: 1.4.0
-      strip-ansi: 7.1.2
-
-  string-width@8.1.0:
-    dependencies:
-      get-east-asian-width: 1.4.0
+      get-east-asian-width: 1.5.0
       strip-ansi: 7.1.2
 
   strip-ansi@6.0.1:
@@ -841,34 +839,32 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
   supports-color@10.2.2: {}
+
+  terminal-size@4.0.1: {}
 
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
-  undici-types@7.16.0: {}
+  undici-types@7.19.2: {}
 
-  wordwrap@1.0.0: {}
-
-  wrap-ansi@9.0.2:
+  wrap-ansi@10.0.0:
     dependencies:
       ansi-styles: 6.2.3
-      string-width: 7.2.0
-      strip-ansi: 7.1.2
+      string-width: 8.2.0
+      strip-ansi: 7.2.0
 
-  yargs-parser@21.1.1: {}
-
-  youch-terminal@2.2.3:
-    dependencies:
-      kleur: 4.1.5
-      string-width: 4.2.3
-      wordwrap: 1.0.0
+  yargs-parser@22.0.0: {}
 
   youch@3.3.4:
     dependencies:
       cookie: 0.7.2
       mustache: 4.2.0
-      stacktracey: 2.1.8
+      stacktracey: 2.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  binaryen@129.0.0-nightly.20260419:
+    hash: 20739acd602f8b086ad5e9fad13190d3c17f34b439314689e5ca49189b9ea49d
+    path: patches/binaryen@129.0.0-nightly.20260419.patch
+
 importers:
 
   .:
@@ -81,8 +86,8 @@ importers:
         specifier: workspace:*
         version: link:../diagnostics
       binaryen:
-        specifier: 129.0.0
-        version: 129.0.0
+        specifier: 129.0.0-nightly.20260419
+        version: 129.0.0-nightly.20260419(patch_hash=20739acd602f8b086ad5e9fad13190d3c17f34b439314689e5ca49189b9ea49d)
       ohm-js:
         specifier: 17.5.0
         version: 17.5.0
@@ -275,8 +280,8 @@ packages:
   as-table@1.0.55:
     resolution: {integrity: sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==}
 
-  binaryen@129.0.0:
-    resolution: {integrity: sha512-NyF5J0SfRoLDthpPh36FGTycOEv3Eqnkq3+mP5Cqt6iD9BLGGJMEVuPzu81nhLy2MMpPKmRTM9VLZihfyRQv8A==}
+  binaryen@129.0.0-nightly.20260419:
+    resolution: {integrity: sha512-5Oir3mh24oUnPbeamIvyR90hWeeLekDBs1omWQTTkpIekC3UY2p5zhFy9MwbjdskVzw/HHNd729aROuhU3daYA==}
     hasBin: true
 
   braces@3.0.3:
@@ -661,7 +666,7 @@ snapshots:
     dependencies:
       printable-characters: 1.0.42
 
-  binaryen@129.0.0: {}
+  binaryen@129.0.0-nightly.20260419(patch_hash=20739acd602f8b086ad5e9fad13190d3c17f34b439314689e5ca49189b9ea49d): {}
 
   braces@3.0.3:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
 		"allowJs": false,
 		"allowUnreachableCode": false,
 		"allowUnusedLabels": false,
-		"baseUrl": "./",
 		"declaration": true,
 		"declarationMap": true,
 		"esModuleInterop": true,
@@ -29,6 +28,7 @@
 		"sourceMap": true,
 		"strict": true,
 		"target": "ESNext",
+		"types": ["node"],
 		"verbatimModuleSyntax": true
 	}
 }


### PR DESCRIPTION
## Summary

Bump every direct dependency and the toolchain to the latest pinned version. Fix the breaking changes that came with it.

### Direct dependencies

| Package | Before | After |
|---|---|---|
| `@adonisjs/ace` | 13.4.0 | 14.1.0 |
| `@biomejs/biome` | 2.3.12 | 2.4.12 |
| `@types/node` | 25.0.10 | 25.6.0 |
| `binaryen` | 125.0.0 | **129.0.0** |
| `fast-check` | 4.5.3 | 4.7.0 |
| `ohm-js` | 17.3.0 | 17.5.0 |
| `typescript` | 5.9.3 | **6.0.3** |

### Toolchain

| Tool | Before | After |
|---|---|---|
| `node` | 24.13.0 | 24.15.0 (LTS) |
| `pnpm` | 10.28.0 | 10.33.0 |

### Breaking-change fixes

- **TypeScript 6**: `baseUrl` is now a deprecated-error; removed from `tsconfig.json`. TS6 is also stricter about auto-loading ambient types, so added `"types": ["node"]` to keep Node globals (`performance`) and module declarations (`perf_hooks`, etc.) resolvable.
- **Binaryen 129**: `mod.i64.const(low, high)` was replaced by `mod.i64.const(bigint)`. Bundled `.d.ts` still declares the old signature, so added a small `i64Const()` wrapper plus `combine32BitPartsToBigInt()` helper (reverses existing `splitBigIntTo32BitParts` used by the checker).

### Side effects

- `pnpm update picomatch -r` bumped picomatch 2.3.1 → 2.3.2 in `pnpm-lock.yaml`, closing the two open Dependabot alerts on `trunk` (GHSA-c2c7-rcm5-vvqj high, GHSA-3v7f-55p6-f55p medium).
- Biome 2.4.12 applied formatter/organize-imports auto-fixes in `declarations.ts` and `compile.property.test.ts`.

## Test plan
- [x] `mise run ci` green — build, biome, tsc, tests (857 tests passing)
- [ ] CI on `trunk` runner green
- [ ] Dependabot alerts auto-close on next scan

Fixes the two open picomatch Dependabot alerts.