### PR TITLE
feat(ci): check-action-versions v2 pilot

### DIFF
--- a/.github/workflows/check-action-versions-v2.yml
+++ b/.github/workflows/check-action-versions-v2.yml
@@ -1,0 +1,32 @@
+name: Check Action Versions (v2 pilot)
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+on:
+  schedule:
+    - cron: '30 9 * * 1'
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ secrets.ACTION_UPDATER_PAT }}
+
+      - uses: nerdalytics/check-action-versions@800cc33a5c20ca73557cc7358a1c1f0b91f0a90a # v1
+        with:
+          committer-name: nerdalytics
+          committer-email: 97166791+nerdalytics@users.noreply.github.com
+          commit-prefix: 'chore(core):'
+          branch-name: update-github-actions-v2
+          issue-title: 'Security: Outdated GitHub Actions detected (v2 pilot)'
+          pr-labels: 'security,dependencies'
+          issue-labels: 'security,dependencies'
+          signing-method: ssh
+          gh-pat: ${{ secrets.ACTION_UPDATER_PAT }}
+          signing-key: ${{ secrets.SSH_SIGNING_KEY }}
+          signing-passphrase: ${{ secrets.SSH_SIGNING_KEY_PASSPHRASE }}


### PR DESCRIPTION
Phase 4 pilot of the shared composite action at `nerdalytics/check-action-versions@800cc33a5c20ca73557cc7358a1c1f0b91f0a90a # v1`. Keeps existing `check-action-versions.yml` untouched.

Deliberate collision avoidance vs existing workflow:
- Filename: `check-action-versions-v2.yml`
- Cron: `30 9 * * 1` (30-min offset)
- `branch-name: update-github-actions-v2`
- `issue-title: ... (v2 pilot)`

These overrides will be removed at cutover (Phase 4 Task 27) so the new workflow takes over canonical names and any continuity automatically.

The equivalent rollout in beacon (PRs #135, #140, #141) completed green across both outdated and up-to-date code paths.