### PR TITLE
chore(tooling): upgrade Node and pnpm

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,8 +1,4 @@
 # mise configuration for tinywhale monorepo
-[tools]
-node = "24.15.0"
-pnpm = "10.33.0"
-
 [tasks.install]
 description = "Install dependencies"
 run = "pnpm install"
@@ -96,3 +92,6 @@ node packages/cli-grammar-test/dist/cli/index.js analyze \
   ${usage_format:+--format "$usage_format"} \
   ${usage_grammar?}
 """
+
+[settings]
+minimum_release_age = "1d"

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
 		"typescript": "6.0.3"
 	},
 	"engines": {
-		"node": "24.15.0",
-		"pnpm": "10.33.0"
+		"node": "26.5.0",
+		"pnpm": "11.16.0"
 	},
 	"keywords": [
 		"compiler",
@@ -18,12 +18,7 @@
 	],
 	"license": "MIT",
 	"name": "tinywhale",
-	"packageManager": "pnpm@10.33.0",
-	"pnpm": {
-		"patchedDependencies": {
-			"binaryen@129.0.0-nightly.20260419": "patches/binaryen@129.0.0-nightly.20260419.patch"
-		}
-	},
+	"packageManager": "pnpm@11.16.0",
 	"private": true,
 	"scripts": {
 		"start": "mise run"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 packages:
   - 'packages/*'
+
+patchedDependencies:
+  binaryen@129.0.0-nightly.20260419: patches/binaryen@129.0.0-nightly.20260419.patch


### PR DESCRIPTION
## What changed

- Upgrade the project toolchain to Node 26.5.0 and pnpm 11.16.0.
- Keep mise tool pins in the local-only `mise.local.toml` configuration.
- Update `package.json` engine constraints and `packageManager` to match.
- Move `patchedDependencies` to `pnpm-workspace.yaml`, where pnpm 11 reads it.
- Set mise's project-wide minimum release age to one day.

## Why

This keeps the runtime and package-manager declarations aligned across mise and package metadata while adopting pnpm 11's supported workspace configuration.

## Impact

Developers use Node 26 and pnpm 11 for this repository. Newly published mise-managed tool releases remain unavailable until they are one day old.

## Validation

- Installed dependencies with pnpm 11.16.0.
- Ran the full `mise run ci` pipeline: build, lint, typecheck, and tests passed.
