### PR TITLE
fix(ci): run build workflow on trunk

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,9 +2,9 @@ name: Build and Test
 
 on:
   push:
-    branches: [main]
+    branches: [trunk]
   pull_request:
-    branches: [main]
+    branches: [trunk]
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:


### PR DESCRIPTION
## What changed

- Change the build workflow's push trigger from `main` to `trunk`.
- Change the build workflow's pull-request target from `main` to `trunk`.

## Why

TinyWhale's default and protected branch is `trunk`. The workflow targeted the nonexistent `main` branch, so it did not validate pushes or pull requests for the actual integration branch.

## Impact

Build, lint, typecheck, and test validation now runs for pull requests targeting `trunk` and for pushes merged into `trunk`.

## Validation

- Ran the full `mise run ci` pipeline successfully.
- Verified both workflow branch filters now target `trunk`.
