### PR TITLE
fix(ci): install declared runtimes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,6 +21,18 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Configure runtime versions
+        shell: bash
+        run: |
+          node -e '
+            const packageJson = require("./package.json");
+            const pnpmVersion = packageJson.packageManager.replace(/^pnpm@/, "");
+            if (pnpmVersion !== packageJson.engines.pnpm) {
+              throw new Error("packageManager and engines.pnpm must match");
+            }
+            process.stdout.write(`node ${packageJson.engines.node}\npnpm ${pnpmVersion}\n`);
+          ' > .tool-versions
+
       - name: Setup mise
         uses: jdx/mise-action@f10502fc09dadecfefb962fff68ce77213930204 # v4.2.2
         with:

--- a/README.md
+++ b/README.md
@@ -6,25 +6,39 @@ A tiny programming language that compiles to WebAssembly.
 
 This is a monorepo managed with [pnpm](https://pnpm.io/) workspaces:
 
-- **`packages/compiler`** - The TinyWhale compiler library
-- **`packages/cli`** - Command-line interface for TinyWhale
-- **`packages/diagnostics`** - Shared diagnostic types and definitions
-- **`packages/lsp`** - Language Server Protocol implementation
+- **`packages/compiler`** — TinyWhale compiler library
+- **`packages/cli-compiler`** — Compiler command-line interface
+- **`packages/grammar-test`** — Grammar testing library
+- **`packages/cli-grammar-test`** — Grammar testing command-line interface
+- **`packages/diagnostics`** — Shared diagnostic types
+- **`packages/lsp`** — Language Server Protocol implementation
+- **`packages/cli-lsp`** — Language server command-line interface
 
 ## Prerequisites
 
-- [mise](https://mise.jdx.dev/) - Development tool version manager and task runner
-- Node.js 24.13.0 (automatically installed via mise)
-- pnpm 10.28.1 (automatically installed via mise)
+- [mise](https://mise.jdx.dev/) — development tool version manager and task runner
+- Node.js 26.5.0
+- pnpm 11.16.0
 
 ## Getting Started
 
 1. Install mise if you haven't already:
+
    ```bash
    curl https://mise.run | sh
    ```
 
-2. Install tools and dependencies:
+2. Create an ignored `mise.local.toml` so mise can install and activate the
+   project runtimes:
+
+   ```toml
+   [tools]
+   node = "26.5.0"
+   pnpm = "11.16.0"
+   ```
+
+3. Install the tools and dependencies:
+
    ```bash
    mise install
    mise run install
@@ -34,18 +48,27 @@ This is a monorepo managed with [pnpm](https://pnpm.io/) workspaces:
 
 All tasks are defined in `mise.toml` and run via mise:
 
-- `mise run install` - Install dependencies
-- `mise run build` - Build all packages
-- `mise run test` - Run tests
-- `mise run check` - Lint and format (Biome, with auto-fix)
-- `mise run typecheck` - TypeScript type checking
-- `mise run clean` - Clean build artifacts
-- `mise run generate-grammar` - Regenerate Ohm grammar bundles
-- `mise run cli <file>` - Run the TinyWhale CLI
+- `mise run install` — install dependencies
+- `mise run build` — build all packages
+- `mise run test` — run tests
+- `mise run check` — lint and format with Biome, applying fixes
+- `mise run typecheck` — run TypeScript type checking
+- `mise run clean` — remove build artifacts
+- `mise run generate-grammar` — regenerate Ohm grammar bundles
+- `mise run cli <file>` — run the TinyWhale compiler CLI
+- `mise run grammar-test [files]` — run grammar tests
+- `mise run grammar-analyze <grammar>` — analyze a grammar
 
 ## Development
 
-The project uses mise as the task runner. All tasks are defined in `mise.toml`.
+Use `mise run ci` for the authoritative full check. It generates the compiler
+grammar bundles, builds every package, runs Biome without modifying files,
+typechecks every workspace, and runs all configured tests.
+
+`package.json` is the source of truth for Node and pnpm versions. Keep its
+`engines` and `packageManager` declarations synchronized with
+`mise.local.toml`. GitHub Actions generates an ephemeral `.tool-versions` from
+those tracked declarations before mise installs the CI runtimes.
 
 ## License
 


### PR DESCRIPTION
## What changed

- Generate an ephemeral `.tool-versions` from the tracked `package.json`
  runtime declarations before `mise-action` runs.
- Fail early if `packageManager` and `engines.pnpm` disagree.
- Refresh the README with the current package layout, Node 26.5.0, pnpm
  11.16.0, local `mise.local.toml` setup, available tasks, and the
  authoritative `mise run ci` workflow.

## Why

The first `trunk` build enabled by #90 failed before dependency installation.
CI had no tracked mise tool declarations because `mise.local.toml` is
intentionally ignored, so `pnpm store path --silent` failed with
`pnpm: command not found`. That left the cache `path` empty and caused
`actions/cache` to stop the job.

Generating `.tool-versions` before setup lets the pinned mise action install
the exact runtimes declared by the project without committing developer-local
tool configuration.

## Impact

GitHub Actions can install Node and pnpm before resolving the pnpm store, while
local contributors retain ignored per-checkout mise configuration. Runtime
version drift between the pnpm engine and package-manager declaration now
fails during setup.

## Validation

- Reproduced the original failure in GitHub Actions run 30111620541.
- Verified the generated tool declarations are exactly `node 26.5.0` and
  `pnpm 11.16.0`.
- Ran `git diff --check` successfully.
- Ran the full `mise run ci` pipeline successfully.
- GitHub Actions `Build and Test` passed in run 30114935725.
