### PR TITLE
docs: reconcile functions roadmap

### DIFF
--- a/docs/2026-01-19-functions-roadmap.md
+++ b/docs/2026-01-19-functions-roadmap.md
@@ -1,286 +1,180 @@
 # Functions Roadmap
 
-## Overview
+> **Updated:** 2026-07-24
 
-Add first-class functions to TinyWhale with the following capabilities:
-- Named functions and lambdas (same syntax)
-- Forward declarations for recursion
-- Higher-order functions (functions as values)
-- Tuple return types with destructuring
-- Extern bindings (WASM intrinsics and host imports)
-- Shadowing warnings for function types
+## Current State
 
-## PR Status
+TinyWhale supports the foundations for functions:
 
-| PR | Scope | Status | Notes |
-|----|-------|--------|-------|
-| **PR 1** | Basic functions, parameters, calls, forward declarations | ✅ **MERGED** | [#53](https://github.com/nerdalytics/tinywhale/pull/53) - Single-expression bodies only |
-| **PR 2** | Expression unification (everything is an expression) | Pending | **Replaces old PR 4** — See [expression-unification.md](../../docs/plans/2026-01-21-expression-unification.md) |
-| **PR 3** | Higher-order functions, lambdas as expressions | Pending | Depends on PR 2 |
-| **PR 4** | Tuples: types, literals, destructuring | Pending | Depends on PR 2 |
-| **PR 5** | Closures (variable capture) | Pending | Depends on PR 2 |
-| **PR 6** | Extern bindings: `extern wasm`, `extern host` | Pending | Depends on PR 2 |
+- Named function bindings and function type aliases
+- Forward declarations
+- Direct calls with arity and argument type checking
+- Single-expression and multi-line function bodies
+- Expression sequences whose final expression supplies the result
+- Bindings, matches, panic, and lambdas in the unified expression model
 
-## Design Change: Expression Unification
+The implementation landed in:
 
-During PR 1 implementation, we discovered that the statement/expression split creates unnecessary complexity. **PR 2 now implements expression unification** — everything becomes an expression:
+- [#53](https://github.com/nerdalytics/tinywhale/pull/53) — basic functions,
+  parameters, direct calls, and forward declarations
+- [#54](https://github.com/nerdalytics/tinywhale/pull/54) — initial expression
+  unification and simplified record syntax
+- [#56](https://github.com/nerdalytics/tinywhale/pull/56) — completed expression
+  unification, multi-line bodies, and removal of obsolete statement machinery
 
-- Bindings evaluate to `None`
-- Type definitions evaluate to `None`
-- `panic` evaluates to `Never`
-- Function bodies are expression sequences (last expression is return value)
-- No `type` keyword — PascalCase identifies types
+Higher-order functions are not implemented. Function types exist in the
+checker, but ordinary runtime function values, inline expected-type lambdas,
+WebAssembly tables, and indirect calls do not.
 
-This change simplifies the grammar and enables multi-line function bodies and nested definitions naturally.
+## TinyWhale 0.1 Milestone
 
-See full design: [docs/plans/2026-01-21-expression-unification.md](../../docs/plans/2026-01-21-expression-unification.md)
-
-## Known Limitations (PR 1)
-
-The following features don't work yet due to `LambdaBody = Expression` (no block support):
+The next language milestone is non-capturing first-class function values and
+higher-order functions.
 
 ```tinywhale
-# ❌ Multi-line function bodies
-factorial = (n: i32): i32 ->
-    match n              # ERROR: body must be single expression
-        0 -> 1
-        _ -> n * factorial(n - 1)
+Unary = (i32) -> i32
 
-# ❌ Nested function definitions
-outer = (x: i32): i32 ->
-    helper = (y: i32): i32 -> y * 2   # ERROR: can't define functions in body
-    helper(x)
+apply_twice = (f: Unary, x: i32): i32 -> f(f(x))
+increment: Unary = (n: i32): i32 -> n + 1
 
-# ❌ Mutual recursion (forward decl works, calling doesn't)
-is_even: (i32) -> i32
-is_odd: (i32) -> i32
-is_even = (n: i32): i32 -> is_odd(n)  # ERROR: is_odd not yet defined
+named_result: i32 = apply_twice(increment, 5)
+inline_result: i32 = apply_twice((n: i32): i32 -> n * 2, 3)
 ```
 
-**What works:**
+Expected results:
+
+- `named_result` evaluates to `7`.
+- `inline_result` evaluates to `12`.
+- Static calls continue to emit direct WebAssembly calls.
+- Calls through function values emit `call_indirect`.
+- Capturing lambdas produce a dedicated checker diagnostic until closures
+  exist.
+
+Tuples, closures, extern bindings, and aggregate runtime representation are
+outside this milestone.
+
+## Implementation Sequence
+
+| Stage | Scope | Status |
+|---|---|---|
+| Foundations | Basic functions and expression unification | Merged in #53, #54, and #56 |
+| Call SemIR | Store explicit argument instruction IDs instead of reconstructing them positionally | Next |
+| Bottom type | Separate `Never` from effect-only `None` | Pending |
+| Function values | Check named function values, function-valued bindings, and expected-type inline lambdas | Pending |
+| Indirect lowering | Emit signatures, a function table, element segments, and `call_indirect` | Pending |
+| Typed fuzzing | Generate valid and invalid function programs, including nested calls and captures | Pending |
+| Extern bindings | Add host imports and approved WebAssembly intrinsics | Later |
+| Runtime values | Choose a shared representation for aggregates and closure environments | Design required |
+
+### 1. Represent Call Arguments Explicitly
+
+The checker computes each argument's `InstId`, but a `Call` currently retains
+only the callee instruction and argument count. Code generation reconstructs
+arguments from instruction position.
+
+Replace that positional assumption with an explicit argument block or side
+table. A call needs:
+
+```text
+callee: InstId
+arguments: InstBlockId
+resultType: TypeId
+```
+
+Regression coverage must include arguments that emit nested semantic
+instructions:
+
 ```tinywhale
-# ✅ Single-expression functions
-double = (x: i32): i32 -> x * 2
+identity = (x: i32): i32 -> x
 add = (a: i32, b: i32): i32 -> a + b
 
-# ✅ Forward declarations
-factorial: (i32) -> i32
-
-# ✅ Function calls
-result:i32 = double(21)
+x: i32 = identity(1 + 2)
+y: i32 = add(identity(3), 4 * 5)
 ```
 
-**These limitations are resolved by PR 2 (expression unification).**
+Both modules must validate and preserve the correct operands.
 
----
+### 2. Separate `Never` from `None`
 
-## Syntax Design (Target)
+`None` represents declarations and effect-only expressions that produce no
+value. `Never` represents expressions such as `panic` that do not return.
 
-### Named Functions
+Add distinct `TypeKind.Never` and `BuiltinTypeId.Never` entries, and make only
+`Never` a subtype of every type. `None` must be compatible only with `None`.
+
+### 3. Check Non-Capturing Function Values
+
+Add semantic representation for a function reference, then support:
+
+- Named functions passed as arguments
+- Function-valued bindings
+- Inline lambdas checked against an expected function type
+- Anonymous synthetic function identities
+- Indirect-call arity and type validation
+- Forward-declared functions used as values once defined
+- Signature-based structural equality
+
+The first implementation must reject captures deliberately:
 
 ```tinywhale
-# Single expression body (works now)
-double = (x: i32): i32 -> x * 2
-
-# Multi-line body (requires PR 2)
-factorial: (i32) -> i32
-factorial = (n: i32): i32 ->
-    match n
-        0 -> 1
-        _ -> n * factorial(n - 1)
+offset: i32 = 10
+add_offset = (n: i32): i32 -> n + offset
+# Error: lambda captures `offset`; closures are not implemented
 ```
 
-### Type Aliases (PR 2 — no `type` keyword)
+### 4. Lower Function Values
 
-```tinywhale
-Person                            # PascalCase + block = record type
-    id: i32
-    age: i32
+Assign stable table indices to runtime function values and intern WebAssembly
+signatures. Emit:
 
-BinaryOp = (i32, i32) -> i32      # PascalCase = type alias
-Percentage = i32<min=0, max=100>  # bounded type alias
+- A function table
+- Element segments
+- `call_indirect` for dynamic callees
+- Direct `call` for statically known callees
 
-add: BinaryOp = (a, b) -> a + b   # value binding with type alias
+Generated modules must validate before and after Binaryen optimization.
+
+### 5. Extend Property-Based Testing
+
+Add grammar-aware generators for:
+
+- Function signatures
+- Valid non-capturing lambda bodies
+- Direct and indirect calls
+- Nested call expressions
+- Deliberate arity and type mismatches
+- Capturing lambdas
+- Multiple signatures in one module
+
+Every generated program that passes checking must produce valid WebAssembly.
+
+## Later Work
+
+After higher-order functions:
+
+1. Add extern host bindings so compiled programs can communicate with their
+   runtime.
+2. Decide aggregate and closure representation in one architecture decision
+   record.
+3. Implement tuples and closure environments using that shared representation.
+
+The runtime-value decision must cover records, lists, tuples, closure
+environments, and the host ABI together. Candidate families include:
+
+- Linear-memory values with explicit layouts and handles
+- WebAssembly GC reference types
+- A constrained local and multi-value representation
+
+Choosing representation independently for each feature would create
+incompatible values and repeated lowering work.
+
+## Verification
+
+Each implementation PR must pass:
+
+```fish
+mise run ci
 ```
 
-### Higher-Order Functions (PR 3)
-
-```tinywhale
-apply_twice = (f: (i32) -> i32, x: i32): i32 -> f(f(x))
-result = apply_twice((n: i32): i32 -> n + 1, 5)  # result = 7
-```
-
-### Tuple Returns (PR 4)
-
-```tinywhale
-div_mod = (a: i32, b: i32): {i32, i32} -> {a / b, a % b}
-{quotient, remainder} = div_mod(10, 3)
-```
-
-### Extern Bindings (PR 6)
-
-```tinywhale
-# WASM intrinsics
-clz: (i32) -> i32
-clz = extern wasm "i32.clz"
-
-# Host imports (with @ prefix for effects)
-@log: (i32) -> None
-@log = extern host "env" "log"
-```
-
----
-
-## PR 2: Expression Unification
-
-**This PR replaces the old PR 4 (Nested Functions and Multi-line Bodies).**
-
-See detailed plan: [docs/plans/2026-01-21-expression-unification.md](../../docs/plans/2026-01-21-expression-unification.md)
-
-### Core Changes
-
-1. Remove statement/expression distinction — everything is an expression
-2. Remove `type` keyword — PascalCase identifies types
-3. Bindings, type definitions, forward declarations evaluate to `None`
-4. `panic` evaluates to `Never`
-5. Expression sequences: last expression is the return value
-
-### What This Enables
-
-- Multi-line function bodies (expression sequences)
-- Nested function definitions (bindings inside bindings)
-- Cleaner grammar (no `Statement` rule)
-
----
-
-## PR 3: Higher-Order Functions and Lambdas
-
-### Scope
-- Function types as first-class values
-- Lambdas as expressions (not just bound)
-- Passing functions as arguments
-- Type inference for lambda parameters from context
-
-### Grammar Changes
-
-```ohm
-// Lambda becomes a valid Expression
-Expression += Lambda
-
-// Function parameter can have function type
-Parameter = identifier colon TypeRef  // TypeRef includes FuncType
-```
-
-### Implementation Steps
-
-1. Allow Lambda in expression position
-2. Handle function-typed parameters
-3. Support calling through variables (indirect calls)
-4. Type inference from parameter context
-
----
-
-## PR 4: Tuples
-
-### Scope
-- Tuple types: `{T1, T2, ...}`
-- Tuple literals: `{expr1, expr2, ...}`
-- Tuple destructuring: `{a, b} = expr`
-
-### Grammar
-
-```ohm
-TupleType = lbrace TypeList rbrace
-TupleLiteral = lbrace ExpressionList rbrace
-TupleBinding = TuplePattern equals Expression
-TuplePattern = lbrace PatternList rbrace
-PatternList = (identifier | underscore) (comma (identifier | underscore))*
-```
-
-### Implementation Steps
-
-1. Add Tuple to TypeKind
-2. Handle tuple literals
-3. Handle tuple destructuring
-4. Codegen for tuples (WASM multi-value or struct)
-
----
-
-## PR 5: Closures
-
-### Scope
-- Identify free variables in nested functions
-- Generate environment structs for captured variables
-- Closure conversion in codegen
-
-### Implementation Steps
-
-1. Track variable references across scope boundaries
-2. Identify captured variables (free variables)
-3. Generate environment struct type
-4. Modify function signature to accept environment
-5. Emit closure construction at definition site
-6. Emit environment access in closure body
-
----
-
-## PR 6: Extern Bindings
-
-### Scope
-- `extern wasm "opcode"` for WASM intrinsics
-- `extern host "module" "function"` for host imports
-- `@` prefix requirement for host imports
-- Opcode whitelist
-
-### Grammar
-
-```ohm
-FuncExpr = ExternWasm | ExternHost | Lambda
-ExternWasm = externKeyword wasmKeyword stringLiteral
-ExternHost = externKeyword hostKeyword stringLiteral stringLiteral
-
-externKeyword = "extern" ~identifierPart
-wasmKeyword = "wasm" ~identifierPart
-hostKeyword = "host" ~identifierPart
-```
-
-### WASM Intrinsic Whitelist
-
-Pure operations only:
-- Integer arithmetic: `i32.add`, `i32.sub`, `i32.mul`, `i32.div_s`, etc.
-- Bitwise: `i32.and`, `i32.or`, `i32.xor`, `i32.shl`, etc.
-- Bit counting: `i32.clz`, `i32.ctz`, `i32.popcnt`
-- Float math: `f32.sqrt`, `f32.abs`, `f32.ceil`, `f32.floor`, etc.
-- Conversions: `i32.wrap_i64`, `f32.convert_i32_s`, etc.
-
----
-
-## Type System (Reference)
-
-### Type Kinds
-
-```typescript
-enum TypeKind {
-  None, I32, I64, F32, F64, Distinct, Record, List, Refined,
-  Func,   // (params) -> return  ✅ Implemented
-  Tuple,  // {T1, T2, ...}       Pending (PR 4)
-}
-```
-
-### Type Compatibility
-
-- `Never` is subtype of all types (bottom type)
-- `None` only compatible with `None`
-- Func types use structural equality
-- Tuple types use structural equality
-
----
-
-## Verification Checklist
-
-For each PR:
-- [ ] `mise run build` succeeds
-- [ ] `mise run test` all pass
-- [ ] `mise run check` no lint errors
-- [ ] `mise run typecheck` no type errors
-- [ ] Example files compile and produce valid WASM
+Feature PRs must also include focused semantic and WebAssembly validation tests
+for their new behavior.

--- a/docs/2026-01-20-grammar-discrepancies.md
+++ b/docs/2026-01-20-grammar-discrepancies.md
@@ -1,6 +1,6 @@
 # Grammar vs Semantic Discrepancies Analysis
 
-> **Date:** 2026-01-20 (Updated: 2026-01-24)
+> **Date:** 2026-01-20 (Updated: 2026-07-24)
 > **Purpose:** Identify discrepancies between grammar (what parses) and semantics (what compiles) to prepare for property-based compiler fuzzing.
 > **Design Philosophy:** Strict grammar - grammar should only accept what the compiler can actually compile.
 
@@ -8,7 +8,7 @@
 
 ## Major Updates Since Original Analysis
 
-**PR #53-56: Functions and Expression Unification**
+**PRs #53, #54, and #56: Functions and Expression Unification**
 - Basic functions implemented (lambdas, declarations, direct calls)
 - "Everything is an expression" design completed
 - Removed: `Statement`, `PanicStatement`, `FuncBinding`, `PrimitiveBinding`, `RecordBinding` grammar rules
@@ -457,7 +457,7 @@ FuncCall = PostfixableBase lparen Arguments rparen
 FuncDecl = identifier colon FuncType
 ```
 
-**Implemented in PRs #53-56:**
+**Implemented in PRs #53, #54, and #56:**
 - Lambda expressions with parameters and return types
 - Function declarations for forward references
 - Direct function calls with arguments
@@ -653,15 +653,17 @@ Data
 
 d = Data
     items = [1, 2, 3]
-# Error: WASM validator - local.set's value type must be correct
+# Error TWCHECK012: type mismatch for list literal
 ```
-List field declaration works, but initialization produces invalid WASM.
+List field declaration works, but the checker rejects list literal
+initialization before code generation.
 
 ```ohm
 FieldInit = lowerIdentifier (colon upperIdentifier | equals Expression)
 ```
 
-**Discrepancy:** `Expression` in `FieldInit` includes `ListLiteral`, but codegen doesn't handle list field initialization correctly.
+**Discrepancy:** `Expression` in `FieldInit` includes `ListLiteral`, but record
+field checking and lowering do not support list-valued fields.
 
 ---
 
@@ -689,7 +691,8 @@ Should allow lists with record element types, initialized via variable reference
 
 **Discrepancy:** Records are flattened to individual fields. Need WASM GC structs or similar to support whole-record references in lists.
 
-**Note:** Functions are now implemented (PR #53-56), but this issue remains because records are still flattened at the codegen level.
+**Note:** Functions are now implemented in PRs #53, #54, and #56, but this
+issue remains because records are still flattened at the codegen level.
 
 ---
 
@@ -759,15 +762,16 @@ Open design question. Not adding trailing comma support until decided.
 
 ### F5. Functions (Partial)
 
-**Basic functions implemented in PRs #53-56:**
+**Basic functions implemented in PRs #53, #54, and #56:**
 - Lambda expressions, function declarations, direct calls
 - Multi-line bodies, type inference from aliases
 
-**Still pending (per original plan `2026-01-19-functions-roadmap.md`):**
-- PR 3: Higher-order functions (indirect calls via `call_indirect`)
-- PR 4: Tuples (types, literals, destructuring)
-- PR 5: Closures (variable capture)
-- PR 6: Extern bindings (`extern wasm`, `extern host`)
+**Still pending (see `2026-01-19-functions-roadmap.md`):**
+- Explicit call-argument representation in SemIR
+- Non-capturing function values and indirect calls
+- Tuples (types, literals, destructuring)
+- Closures (variable capture)
+- Extern bindings (`extern wasm`, `extern host`)
 
 ---
 
@@ -785,7 +789,8 @@ Open design question. Not adding trailing comma support until decided.
 - Integer scientific notation negative exponents rejected at grammar level
 - Binding patterns in match now work with lexical scoping
 - Refinement types in field declarations now enforced
-- Basic functions implemented (lambdas, declarations, direct calls)
+- Basic functions implemented in #53, #54, and #56 (lambdas, declarations,
+  direct calls)
 - "Everything is expression" design completed
 - Deprecated Statement-related code removed
 
@@ -793,6 +798,6 @@ Open design question. Not adding trailing comma support until decided.
 1. D1-D2 (nested lists, chained index) - need checker/codegen implementation
 2. D3-D5 (list/record destructuring, guards) - missing grammar + checker
 3. D6 (negative float literals) - grammar change needed
-4. D7 (list fields in records) - codegen fix needed
+4. D7 (list fields in records) - checker and lowering support needed
 5. D8 (lists of user-defined types) - need WASM GC or alternative approach
 6. D9 (float match patterns) - grammar + checker needed


### PR DESCRIPTION
## What changed

- Replace the obsolete conceptual function PR sequence with the current
  implementation status and TinyWhale 0.1 milestone.
- Record the agreed order: explicit call arguments, `Never`, non-capturing
  function values, indirect lowering, and typed fuzzing.
- Add acceptance behavior for named and inline higher-order function calls.
- Correct historical PR references to #53, #54, and #56.
- Update the list-valued record-field discrepancy to reflect the current
  checker rejection rather than the stale invalid-Wasm behavior.

## Why

The roadmap still marked expression unification as pending, linked to a plan
that is no longer present, and described behavior that no longer matches the
compiler. Contributors need a source-grounded continuation point before the
SemIR call-argument refactor begins.

## Impact

This is documentation-only. It establishes non-capturing first-class function
values as the next language milestone and identifies the prerequisites and
non-goals without changing compiler behavior.

## Validation

- Verified the shipped function history against merged PRs #53, #54, and #56.
- Verified the current call, lambda, `None`, and list-field behavior against
  compiler source and tests.
- Confirmed stale roadmap links and claims are removed.
- Ran `git diff --check` successfully.
- Ran the full `mise run ci` pipeline successfully.
- GitHub Actions `Build and Test` passed in run 30116369894.
